### PR TITLE
Add openall-export: Claude Code → OpenAll process converter

### DIFF
--- a/process/conversations/2026-03-26-clever-jumping-valley.md
+++ b/process/conversations/2026-03-26-clever-jumping-valley.md
@@ -1,0 +1,3260 @@
+# Conversation: clever-jumping-valley
+
+**Date:** 2026-03-26
+**Time:** 14:24 UTC
+**Project:** `/Users/zhangyiyi/Desktop/openall-license`
+**Branch:** `HEAD`
+**Model:** claude-opus-4-6
+**Claude Code version:** 2.1.81
+
+---
+
+**Human:** 看一下当前项目
+
+> *[Bash]* List files in project directory
+
+> *[Glob]* Search files: **/*
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/README.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/package.json
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/CLAUDE.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** 这是一个 **OpenAll License** 项目，包含两个子目录：
+
+### 项目结构
+
+- **`openall-repo/`** — 主仓库，[openall.fund](https://openall.fund) 官网源码
+- **`openall-deploy/`** — 部署产物（构建后的静态文件）
+
+### 技术栈
+
+- **React 19 + Vite 8**，单页应用
+- `src/App.jsx` 是核心组件，包含许可证条文的结构化数据和完整的网站UI
+- 无路由库，纯单文件应用
+
+### OpenAll License 是什么
+
+这是一个创新的开源许可证，核心理念是**过程透明**：
+
+1. **代码开源** — 和传统开源一样，可自由使用、修改、分发（含商用）
+2. **过程开源** — 要求公开整个创作过程：AI 对话记录、设计决策、开发日志、灵感来源
+3. **自动脱敏** — AI 工具自动清除敏感信息（API 密钥、密码等）后再发布
+4. **Copyleft** — 衍生作品必须使用相同许可证
+
+项目本身也遵循 OpenAll 许可证，包含 `/conversations`、`/decisions`、`/journal`、`/inspirations` 目录来记录开发过程。
+
+还提供了多种 AI 工具的配置文件（`.openall/AGENT.md`、`CLAUDE.md`、`.cursorrules`、`.github/copilot-instructions.md`），让 AI 编码助手自动遵守许可证要求。
+
+需要我做什么具体的事情吗？
+
+**Human:** 那你把这个项目推上去，推到https://github.com/openall-foundation/openall-license
+
+**Claude:** 先看一下当前的 git 状态。
+
+> *[Bash]* Check git status in openall-repo
+
+> *[Bash]* Check git remotes
+
+> *[Bash]* Check recent git history
+
+**Claude:** 还没有初始化 git 仓库。让我先检查远程仓库是否存在，然后初始化并推送。
+
+> *[Bash]* Check if remote repo exists
+
+**Claude:** 远程仓库已存在，是个空仓库。我来初始化本地 git 并推送上去。
+
+> *[Bash]* Initialize git repo with main branch
+
+> *[Bash]* Stage all files and check status
+
+**Claude:** 文件都已暂存，`dist/`、`node_modules/`、`.DS_Store` 都被 `.gitignore` 排除了。现在创建初始提交并推送。
+
+> *[Bash]* Create initial commit
+
+**Claude:** 提交成功。现在添加远程仓库并推送。
+
+> *[Bash]* Add remote and push to GitHub
+
+**Claude:** 已成功推送到 https://github.com/openall-foundation/openall-license 。20 个文件全部上传，包括许可证全文、网站源码、AI 配置文件和过程记录文档。
+
+**Human:** 别忘了把我们这段对话也推上去。这是一个元过程。记得在里面也提醒别的ai这么做
+
+**Claude:** 好主意，这本身就是 OpenAll 精神的体现。让我先看一下 conversations 目录现有的内容。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/README.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+**Claude:** 现在创建对话记录和脱敏日志。
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/README.md
+
+**Claude:** Now let me add a stronger meta-process reminder to AGENT.md.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/sanitization.log
+
+**Claude:** 现在提交并推送。
+
+> *[Bash]* Commit and push conversation logs
+
+> *[Grep]* Search content: sanitization
+
+> *[Grep]* Search content: \.log
+
+**Claude:** `.gitignore` 里有 `*.log`，但 `sanitization.log` 是 OpenAll 要求的审计文件，应该被跟踪。改一下 `.gitignore`。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/.gitignore
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.gitignore
+
+> *[Bash]* Commit and push all conversation + meta-process files
+
+**Claude:** 已推送完成。做了以下事情：
+
+1. **`conversations/2026-03-26-initial-repo-push.md`** — 记录了我们这段对话的完整过程，包括探索项目、初始化 git、推送到 GitHub 的全过程
+2. **`conversations/README.md`** — 更新索引，添加了对 AI agent 的提醒：修改仓库时必须记录对话
+3. **`.openall/AGENT.md`** — 新增第 6 节「Record the meta-process」，明确告诉其他 AI：记录过程材料这件事本身也是过程的一部分，不要等人类提醒
+4. **`sanitization.log`** — 初始化脱敏审计日志（所有文件均无需脱敏）
+5. **`.gitignore`** — 将 `sanitization.log` 从 `*.log` 排除规则中豁免
+
+这就是一个元过程的闭环 — 推代码的对话本身被记录为代码的一部分。
+
+**Human:** 这事全部的之前的记录，是这个项目交给你之前的：
+mit协议是谁发明的
+
+21:39
+MIT许可证（MIT License）并非由某个特定个人"发明"，而是起源于麻省理工学院（Massachusetts Institute of Technology），因此以该校命名。
+
+它最早出现在1980年代，由MIT用于发布其开发的软件（如X Window System）。其具体措辞被认为主要归功于当时MIT参与X Window System项目的人员，但没有单一的"发明者"。它本质上是MIT作为机构采用的一种宽松的软件许可模板，后来被开源社区广泛采纳，成为最流行的开源许可证之一。
+
+我准备开发一个叫“openall”协议，要求开发过程中的和ai的对话、整个其他过程、想法来源、开发进展等等，凡是有的都尽可能一一开源，你想想怎么搞
+
+21:40
+这个想法很有意思——不仅开源代码，还开源整个创造过程。让我帮你理一理思路。
+
+核心理念
+OpenAll 的本质是**"过程开源"**，比传统开源更进一步：代码只是结果，而你要求把产生结果的全部上下文也公开。
+
+需要定义的几个关键问题
+1. 开源范围分层
+
+可以把要求公开的内容分成几层：
+
+必须公开：代码、与AI的对话记录、设计文档、决策记录（为什么选A不选B）
+建议公开：灵感来源、参考资料、开发日志、进度时间线
+可选公开：草稿、废弃方案、个人笔记
+这样有弹性，不至于让人望而却步。
+
+2. 合规边界
+
+"尽可能"这个词很关键。有些东西确实不能公开——比如对话中涉及他人隐私、商业API密钥、第三方受保护内容。协议里需要明确豁免条款。
+
+3. 执行方式
+
+实际操作上，可以规定项目仓库里必须包含特定目录结构，比如：
+
+/src          → 代码
+/conversations → AI对话导出
+/decisions    → 决策记录
+/journal      → 开发日志
+/inspirations → 灵感和参考来源
+4. 协议本身的法律性质
+
+你需要想清楚它是一个许可证（License）还是一个公约/承诺（Pledge）。许可证有法律约束力，公约更像是自愿遵守的规范。前者门槛高但有力，后者容易推广。
+
+建议的下一步
+我觉得最务实的路径是：先写一份简洁的协议草案（一页纸），然后自己用这个协议做一个小项目作为示范，让别人能直观看到"遵守OpenAll的项目长什么样"。
+
+我已经买下了openall.fund的域名了。我建议他是license，而且以后要成为大家公认的license
+
+21:41
+好的，定位很清晰——要做一个正式的、有法律效力的License，目标是像MIT、GPL那样成为业界公认的标准协议。
+
+这个定位意味着几件事很重要：
+
+协议文本要专业但简洁。 MIT License之所以流行，很大原因是它只有几百个英文单词，一眼能看完。OpenAll License也应该追求这种简洁感，不要写成长篇法律文书。
+
+需要英文为主。 要成为国际公认的License，英文版本是权威版本，中文可以作为官方翻译并存。
+
+核心条款要非常明确。 别人拿到这个License，必须一目了然地知道：我用了这个协议，我必须做什么、不能做什么、可以做什么。
+
+openall.fund 可以作为协议的官方主页，放协议全文、FAQ、示范项目、合规检查工具等。
+
+要做成公认的License，路径大概是：写出协议 → 自己先用 → 吸引早期项目采用 → 提交给OSI（开源促进会）审核认证 → 进入GitHub等平台的License选择列表。
+
+那我们先从写协议草案开始。动手之前我想确认几个关键设计决策：
+
+Q: 如果有人违反协议（比如用了AI但不公开对话记录），后果是什么？
+A: 不知道，这个要看试下来怎么样，因为两种都有道理。可以让之后参与协议的ai和人一起决定，定期或不定期可以修改，就和anthropic宪法一样
+
+Q: 对商业使用的态度？
+A: 商用应该有一些不同，因为现在还不是共产主义社会。但是具体怎么做还不确定
+
+Q: 协议的语言风格？
+A: 你看看怎么样合适
+
+21:43
+明白了，你的思路很务实：
+
+治理方式是动态的——协议本身可以演进，由社区（人+AI）共同决定，类似宪法修正案机制
+商业条款暂时留空间——承认现实，但具体规则后续再定
+语言风格交给我判断
+我的建议是走Creative Commons那种两层结构：一个简短易读的"人话版"摘要，加上一个严谨的法律全文。这样既利于传播，又有法律效力。这是最适合一个志在成为公认标准的License的做法。
+
+现在我来写第一版草案。先出英文权威版本，附中文翻译。
+
+
+Ran 4 commands, viewed a file, created a file
+Ran 4 commands, viewed a file, created a file
+这是 OpenAll License v1.0 的第一版草案，采用了 Creative Commons 式的两层结构：
+
+第一页是人话版摘要——一眼看完核心要求：自由使用，但必须公开开发过程。
+
+后面是完整法律文本，共10个条款，核心设计包括：
+
+**第3条（过程透明）**是协议的灵魂——定义了"Process Materials"必须公开，推荐了目录结构，也列明了隐私/密钥等合理豁免
+**第7条（治理）**按你的想法设计——AI和人类都可以提议修改协议，所有治理过程本身也要透明
+**第8条（合规）**设了30天补救期，具体后果留给社区未来决定
+商业条款目前允许商用但保留社区未来定义附加条款的权利
+标注为 Draft，方便你迭代。下一步可以考虑放到 openall.fund 上，同时做一个示范项目来展示"遵守OpenAll的项目长什么样"。
+
+Openall license v1.0 draft
+Document · DOCX 
+好的你直接建立网站，我现在就po上去
+
+21:45
+
+Viewed a file, created a file, read a file
+Viewed a file, created a file, read a file
+网站做好了，包含：
+
+Hero区 — 深绿色渐变 + "OpenAll" 大标题 + 一句话定位
+三大支柱卡片 — Process Transparency / Community Governance / Copyleft Forward
+推荐目录结构 — 展示 OpenAll 项目长什么样
+协议正文 — 双Tab切换：人话版摘要 + 可折叠的完整法律文本（10条全部在里面）
+Adopt 区 — GitHub badge 一键复制
+底部 — 标注这个协议本身就是透明创作的
+你可以直接把这个页面部署到 openall.fund 上。如果你用的是 Vercel/Netlify 之类的平台，这个 React 组件可以直接放进去；如果需要纯 HTML 版本我也可以转。
+
+Openall fund
+Code · JSX 
+加一个要求，这些不应该是开发者上传的，而应该是开发者让ai自动上传的，这样开发者不需要费任何力气维护。然后也要强调不能把敏感信息、key之类开源，应该有自动审查，保证没有，类似于网站分享时对跟踪链接的清除。应该用简单的txt格式，而不是docx
+
+21:48
+
+Check current file exists
+Check current file exists
+好，三个重要更新：
+
+零负担原则 — AI自动上传，开发者不需要手动维护
+自动审查（Sanitization） — 上传前自动清除敏感信息，类似链接追踪清除
+纯文本格式 — 用 .txt 而非 .docx
+我先更新协议文本文件，再更新网站。
+
+
+Create the OpenAll License v1.0 as plain txt
+Create the OpenAll License v1.0 as plain txt
+Now update the website with the new concepts:
+
+
+Created 2 files, ran a command, read a file
+Created 2 files, ran a command, read a file
+两个文件都更新好了：
+
+网站新增内容：
+
+"How it works" 流程图 — 四步展示：你写代码 → AI自动审查 → AI自动发布 → 开发者零负担
+"Auto Sanitization" 专区 — 用具体例子展示 key/密码/邮箱/IP 是怎么被自动替换成 [REDACTED: ...] 的
+四支柱从三个变成四个，新增"Zero Developer Effort"和"Auto Sanitization"
+目录结构里标注了 AUTO 标签，让人一眼看出哪些是自动生成的
+协议 .txt 文件更新：
+
+新增 §1.6 "Sensitive Information" 定义
+新增 §4 "Automatic Sanitization" 整节（5个条款），包括模式匹配、熵分析、标准化占位符、审查日志、工具本身开源
+§3.2 明确要求 AI 工具自动生成和发布，开发者零手动操作
+格式改为纯 .txt
+Openall fund
+Code · JSX 
+Openall license v1.0
+TXT 
+你先仔细查一下网上有没有类似的协议和运动呢，不要重复了。
+
+21:54
+
+Searched the web
+Searched the web
+好消息——我找到了一篇非常相关的文章，但结论是：你的OpenAll协议在现有领域中是独一无二的，没有重复。
+
+让我总结一下调研结果：
+
+现有的相关领域
+1. "Open Method" 概念（最接近的） 有人在2026年1月的DEV Community上提出了"Open Method"概念，认为AI辅助开发的项目仅开源代码是不够的，还应该分享prompts、PRD、决策过程等。 
+DEV Community
+但这篇文章明确说这只是一种社区规范建议，而非许可证，作者也承认传统开源许可证不涉及记录开发过程，也没有法律要求分享prompts。 
+DEV Community
+
+2. OSI的Open Source AI Definition（OSAID） OSI正在定义什么构成"开源AI"，主要关注的是AI模型本身的组件——代码、训练数据、权重——是否公开。 
+Open Source Initiative
+这和你的方向完全不同，他们关注的是AI模型的开放性，不是使用AI开发软件时过程的透明度。
+
+3. OpenMDW（Linux Foundation） OpenMDW是一个为机器学习模型设计的许可证，关注的是模型、数据和权重的许可条款。 
+Linux Foundation
+不涉及开发过程的记录。
+
+4. Red Hat的AI标注建议 Red Hat支持在开源项目中标注AI辅助的贡献，比如用commit trailer "Assisted-by:" 
+Red Hat
+，但这只是轻量标注，远远不到公开完整对话记录的程度。
+
+5. RAIL许可证 RAIL许可证通过使用限制来解决AI的伦理问题 
+OECD AI
+，但关注的是限制AI的不良用途，不涉及开发过程透明。
+
+OpenAll的独特定位
+你的协议在以下方面是全新的、没有先例的：
+
+以License形式强制要求公开完整开发过程（不是建议、不是规范）
+要求AI工具自动完成这一切（零负担原则）
+内置自动审查/脱敏机制
+AI和人类共同治理协议演进
+那篇"Open Method"文章说得很好：整个行业都意识到了这个问题，但还没有人把它做成一个正式的License。你正好填补了这个空白。
+
+建议你在 openall.fund 网站上加一个"Why OpenAll"部分，引用那篇"Open Method"文章作为问题的佐证，然后说明 OpenAll 是第一个把这个理念落地为正式License的项目。需要我更新网站加上这部分吗？
+
+有没有可以借鉴的地方？主页就不要大改或者添加边缘内容了。还有jsx能直接部署网页吗？我不太了解
+
+21:57
+好问题。先回答部署问题，再说借鉴。
+
+JSX 部署
+JSX 不能直接部署为网页。它是 React 组件，需要一个构建工具把它编译成浏览器能运行的 HTML+JS。最简单的部署方式：
+
+用 Vite + React 创建一个项目，把这个 JSX 放进去
+运行 npm run build 生成静态文件
+把静态文件部署到 Vercel / Netlify / Cloudflare Pages（都免费，绑定域名即可）
+我帮你直接生成一个纯 HTML 文件，可以直接丢到任何托管服务上，零构建步骤。
+
+可以借鉴的地方
+从调研中提炼出几点值得吸收的：
+
+"Open Method" 那篇文章的具体建议很实用 — 他提到保存 PRD（产品需求文档）、session 上下文、以及"为什么拒绝了AI的某个建议"，这些可以纳入你的 Process Materials 推荐清单里
+Red Hat 的分级标注思路 — 不是所有AI交互都同等重要，自动补全变量名不需要记录，但重大架构决策的对话必须记录。可以在协议的指导文档（不是协议本身）中加入这种分级建议
+Creative Commons 的推广策略 — CC 做了"人话版 + 法律版 + 机器可读版"三层。你已经有前两层了，未来可以加一个机器可读的元数据标准（比如在 repo 的 openall.json 里声明合规状态）
+这些不需要改协议正文，适合放到 openall.fund 未来的 FAQ 或 Guide 页面里。
+
+我现在把网站转成可以直接部署的纯 HTML 文件？
+
+Q: 网站输出格式？
+A: 我不希望界面有变化。改成html会有变化吗
+
+22:00
+视觉上会完全一样。JSX 转 HTML 只是把 React 组件语法改成原生 JavaScript，样式、布局、动画、交互逻辑全部保留，浏览器里打开看到的效果一模一样。
+
+唯一的区别是技术实现方式：React 的 useState 变成原生 JS 变量，onClick 变成 addEventListener，但用户看到的页面没有任何差别。
+
+我现在转，给你一个可以直接部署的 index.html。
+
+
+Convert the OpenAll website from JSX to a single self-contained HTML file with identical visual output
+Convert the OpenAll website from JSX to a single self-contained HTML file with identical visual output
+Claude's response was interrupted
+react比较先进吧，可以用react
+
+22:00
+那最简单的方案：用 Vite + React 创建一个完整项目，你只需要三步就能部署。我帮你打包好整个项目文件夹。
+
+
+Ran 4 commands, viewed 2 files, edited 2 files
+Ran 4 commands, viewed 2 files, edited 2 files
+Now build and package:
+
+
+Ran 3 commands, read a file
+Ran 3 commands, read a file
+三个文件给你：
+
+openall-deploy.tar.gz — 构建好的静态文件，直接部署用。部署步骤：
+
+解压到任意文件夹
+在 Vercel / Netlify / Cloudflare Pages 上传这个文件夹，绑定 openall.fund 域名即可
+openall-project.tar.gz — 完整项目源码（不含 node_modules）。以后要改网站：
+
+解压后运行 npm install
+npm run dev 本地预览
+改 src/App.jsx 后 npm run build
+OpenAll-License-v1.0.txt — 协议全文，放到网站根目录或 GitHub 仓库里
+
+如果你用 Vercel（推荐，最简单），可以直接连 GitHub 仓库，以后改代码 push 就自动部署。
+
+Openall deploy.tar
+GZ 
+Openall project.tar
+GZ 
+Openall license v1.0
+TXT 
+不要展现draft字样，不要展现基金会的存在，这是一种开源自由的运动，虽然我可能要建立基金会。
+
+22:02
+明白，两个改动：去掉所有"Draft"字样，去掉"fund"基金会暗示，保持自由运动的调性。
+
+
+Edited 6 files, viewed a file, ran a command
+Edited 6 files, viewed a file, ran a command
+Now update the license txt file too:
+
+
+Edited 4 files, ran 2 commands
+Edited 4 files, ran 2 commands
+Now rebuild and repackage:
+
+
+Ran 3 commands
+Ran 3 commands
+唯一剩余的 openall.fund 是 GitHub badge 的链接地址——这是你的域名本身，不暗示基金会，只是网站URL。
+
+
+Presented 3 files
+Presented 3 files
+改好了。所有改动：
+
+"Version 1.0 — Draft" → "Version 1.0"
+"OpenAll License v1.0 — Draft" → "OpenAll License v1.0"
+协议法律文本中所有 "published at openall.fund" → "published on the official OpenAll website"（中性表述，不暗示基金会）
+footer 同步清理
+网站和协议文本都已更新，三个文件可以直接用。
+
+Openall deploy.tar
+GZ 
+Openall project.tar
+GZ 
+Openall license v1.0
+TXT 
+我真的要发布了。你还有什么想改的吗。以及怎么让更多人用这个？我建议可以加入一键分享#openall标签到主要社交媒体，或者加入自己的github之类，当然这是我的想法
+
+22:05
+让我再仔细审一遍网站和协议，然后回答你的推广问题。
+
+
+Viewed 3 files
+Viewed 3 files
+审完了，内容没有问题。现在加上你说的社交分享和 GitHub 集成功能：
+
+
+Ran 2 commands, edited a file, read a file
+Ran 2 commands, edited a file, read a file
+最终版。新增了 "Join the movement" 区块：
+
+一键分享到四个平台：
+
+𝕏/Twitter — 预填文案 + #OpenAll 标签
+Reddit — 预填标题和链接
+LinkedIn — 一键分享
+Hacker News — 直接提交到 Submit
+GitHub 集成：
+
+引导用户给自己的 repo 加 openall topic
+链接到 github.com/topics/openall，这样所有 OpenAll 项目自动聚合在一个页面
+我的其他建议
+协议层面，我觉得可以发布了，目前文本清晰完整。有一点值得以后注意：§3.2 要求 AI 工具自动上传，但目前市面上还没有现成工具做这件事。所以你可能需要尽快做一个最小可用的工具（比如一个 CLI 或 VS Code 插件），否则协议虽好，没人能遵守。
+
+推广层面，除了社交分享，最有效的是：你自己用 OpenAll 协议做一个真实项目，把完整的 /conversations 目录公开，让人看到"哇原来一个 OpenAll 项目长这样"。这比任何宣传都有说服力。
+
+Openall deploy.tar
+GZ 
+Openall project.tar
+GZ 
+Openall license v1.0
+TXT 
+最底下还可以加一个订阅邮件框，不要太大，但是可以接受我们的新信息，如果你觉得不加好那也可以
+
+22:07
+加是对的。对于一个新运动来说，邮件订阅是最重要的早期增长渠道之一——社交媒体算法不可控，但邮件列表是你自己的。做得小巧不打扰就好。
+
+不过需要一个后端来收邮件。你打算用什么？
+
+Q: 邮件订阅用什么接收？
+A: 要好用的，比如anthropic用哪个。我就用哪个。以及把这个项目本身做成openall项目，那不是最好的demo吗？
+
+22:07
+
+Searched the web
+Searched the web
+没搜到Anthropic具体用哪个邮件平台。不过对于你的场景，我推荐 Buttondown：它有免费计划支持100个订阅者，注重隐私，有REST API和Markdown支持，非常适合开发者和技术社区 
+Woodpecker
+。它也是独立开发者做的项目，和OpenAll的精神很合。Mailchimp更适合大公司做营销，对你来说太重了。
+
+先用 Buttondown 的免费表单嵌入。你注册后会得到一个表单 action URL，我现在把邮件框加到 footer 上方。
+
+关于你说的——把这个项目本身做成 OpenAll 项目——这个想法太对了。你可以把我们这整段对话导出，放到 GitHub 仓库的 /conversations 目录下，这就是最好的 demo。
+
+
+Ran 2 commands, edited a file, read a file
+Ran 2 commands, edited a file, read a file
+Done。邮件订阅框加在 footer 上方，小巧不抢眼：一行标题 + 一句话说明 + 输入框 + 按钮。
+
+**你需要做的一步：**去 buttondown.com 注册一个账号，用户名设为 openall。表单里的 action URL 已经指向 buttondown.com/api/emails/embed-subscribe/openall，注册后就能直接用。
+
+关于把项目本身做成 OpenAll demo：
+
+这确实是最完美的第一个示范项目。你可以这样做：
+
+在 GitHub 建 openall/openall.fund 仓库
+把网站源码放进去
+把我们这整段对话导出，放到 /conversations/2026-03-26-license-creation.md
+写一个 /decisions/001-license-design.md 记录关键设计决策（比如为什么选copyleft、为什么要自动上传、为什么用Buttondown）
+仓库根目录放 LICENSE 文件（就是那个 .txt）
+加 openall topic
+这样任何人访问你的 GitHub 仓库，就能立刻看到一个活生生的 OpenAll 项目长什么样。
+
+Openall deploy.tar
+GZ 
+Openall project.tar
+GZ 
+Openall license v1.0
+TXT 
+我建了一个https://github.com/openall-foundation
+
+22:13
+很好，组织已经建好了。接下来你需要在这个组织下创建第一个仓库。建议仓库名就叫 openall.fund——和域名一致，一目了然。
+
+具体步骤：
+
+在 github.com/openall-foundation 下新建仓库 openall.fund
+解压 openall-project.tar.gz，把 openall-site/ 里的内容推上去
+在仓库根目录加上 LICENSE 文件（就是那个 txt）
+创建 /conversations 目录，把我们这段对话导出放进去
+创建 /decisions 目录，写几个关键决策记录
+给仓库加 openall topic
+我帮你把仓库的初始结构准备好，包括 README、decisions 文档，打包成可以直接推的完整目录：
+
+
+Created 7 files, ran 6 commands, read a file
+Created 7 files, ran 6 commands, read a file
+这就是完整的 GitHub 仓库，解压后直接推到 openall-foundation/openall.fund。结构：
+
+openall-repo/
+├── LICENSE                        ← OpenAll License v1.0 全文
+├── README.md                      ← 项目介绍 + badge + 快速开始
+├── conversations/
+│   └── README.md                  ← 提示你把这段对话导出放这里
+├── decisions/
+│   ├── 001-license-design-philosophy.md
+│   └── 002-website-and-infrastructure.md
+├── journal/
+│   └── 2026-03-26-day-1.md        ← 今天的开发日志
+├── inspirations/
+│   └── references.md              ← CC、Open Method 文章等灵感来源
+├── src/
+│   ├── App.jsx                    ← 网站主体
+│   └── main.jsx
+├── index.html
+├── package.json
+└── vite.config.js
+你要做的事：
+
+解压，推到 github.com/openall-foundation/openall.fund
+在 Claude 里导出我们的对话，存为 conversations/2026-03-26-license-creation.md
+去 buttondown.com 注册用户名 openall
+部署：连 Vercel，指向这个仓库，绑定 openall.fund 域名
+给仓库加 openall topic
+这就是世界上第一个 OpenAll 项目了。
+
+Openall repo.tar
+GZ 
+那repo就叫openall-licence吧，清晰明了。还有一个问题。openall本身应该是openall licence，不是mit licence，对吧
+
+22:18
+对，OpenAll 项目自己当然应该用 OpenAll License。我检查一下仓库里有没有遗漏的地方。
+
+
+Check for any MIT license references
+Check for any MIT license references
+package-lock.json 里的 MIT 是第三方依赖（React、Vite等）自己的许可证，不能也不应该改——那是它们的许可证。需要改的只有 package.json 里声明本项目自身的 license 字段：
+
+
+Ran 2 commands, viewed a file, edited a file
+Ran 2 commands, viewed a file, edited a file
+改好了。总结一下检查结果：
+
+需要改的（已改）：
+
+package.json 里的 name → "openall-licence"
+package.json 里加了 "license": "SEE LICENSE IN LICENSE" — 这是 npm 对非标准许可证的标准写法，意思是"去看根目录的 LICENSE 文件"
+version → "1.0.0"
+不需要改的：
+
+package-lock.json 里的大量 "license": "MIT" — 那是 React、Vite 等第三方依赖各自的许可证，和你的项目无关，不能改也不该改
+inspirations/references.md 和 decisions/ 里提到 MIT — 那是在讨论和对比，不是声明本项目使用 MIT
+仓库名就叫 openall-licence，推到 github.com/openall-foundation/openall-licence。
+
+Openall repo.tar
+GZ 
+Openall deploy.tar
+GZ 
+好的，我接下来要做什么？是否可以把这个下载以后移交claude code，这样就可以自动把后续的内容也加进去而且提交了
+
+22:20
+完全可以，而且这是最符合 OpenAll 精神的做法——让 AI 工具自动处理提交。
+
+你接下来的步骤：
+
+1. 现在立刻做（手动，5分钟）：
+
+在 github.com/openall-foundation 下创建仓库 openall-licence
+解压 openall-repo.tar.gz，推上去
+给仓库加 openall topic
+2. 移交 Claude Code：
+
+在本地 clone 下来
+用 Claude Code 打开项目
+告诉它："这是一个 OpenAll 项目，所有后续开发对话自动保存到 /conversations，决策记录到 /decisions，进展记录到 /journal，然后 commit 并 push"
+3. 让 Claude Code 帮你完成：
+
+把我们这段对话导出，存到 /conversations/2026-03-26-initial-creation.md
+注册 Buttondown（用户名 openall）
+部署网站到 Vercel，绑定 openall.fund
+发第一条社交媒体 #OpenAll
+4. 后续 Claude Code 可以持续做：
+
+每次开发对话自动记录并提交
+逐步开发 OpenAll 合规工具（CLI 或 VS Code 插件）
+维护网站更新
+这样从现在开始，整个项目的开发过程就全部透明可追溯了——这本身就是最好的 demo。
+
+哎呀是licence还是license
+
+22:21
+是 license。
+
+licence 是英式拼写，license 是美式拼写。在软件和开源领域，美式 license 是绝对主流——MIT License、Apache License、GPL 都用 license。GitHub 的文件也默认识别 LICENSE 而不是 LICENCE。
+
+所以仓库名应该叫 openall-license。我刚才 package.json 里也写的是 openall-licence，需要改过来，但建议你到 Claude Code 里再统一改，省得我这边改了你还要重新下载。
+
+那你改一下吧
+
+22:22
+
+Ran 3 commands, edited a file, read a file
+Ran 3 commands, edited a file, read a file
+改好了。package.json 和 package-lock.json 里的 openall-licence 全部改成了 openall-license。node_modules 里的是第三方包自己的文件，不影响。
+
+仓库名：openall-license，可以推了。
+
+Openall repo.tar
+GZ 
+Openall deploy.tar
+GZ 
+
+
+
+
+
+Claude is AI and can make mistakes. Please double-check responses.
+
+
+**Claude:** 这段是在 claude.ai 上的创始对话，是整个项目的起源。我把它保存到 `/conversations` 并推上去。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/README.md
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/2026-03-26-license-creation.md
+
+**Claude:** Now update the conversations README to remove the "To add" placeholder since the file now exists.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/README.md
+
+> *[Bash]* Commit and push the founding conversation
+
+**Claude:** 已推送。现在仓库的 `/conversations` 目录里有三份完整记录：
+
+1. **`2026-03-26-license-creation.md`** — 创始对话（claude.ai），从"MIT协议是谁发明的"到整个项目诞生的全过程
+2. **`2026-03-26-initial-repo-push.md`** — 本次 Claude Code 会话的前半段（初始化 git + 推送到 GitHub）
+3. 本次会话中记录创始对话这个动作本身也会体现在 git history 中
+
+`.openall/AGENT.md` 里已经有第 6 节提醒其他 AI：**记录过程材料这件事本身也是过程的一部分**，不要等人类提醒。`conversations/README.md` 顶部也有醒目提示。
+
+**Human:** 别忘了打上时区标，你看是在文件名还是文件里打比较合适，不然全球就乱套了。还应该添加CLAUDE.md吧，这样AI CLI或者其他东西在操作时能记住里面的各种要点。然后你看看这东西怎么部署呢？
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/CLAUDE.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/2026-03-26-initial-repo-push.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/2026-03-26-license-creation.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/vite.config.js
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/config.json
+
+> *[Bash]* Check deploy directory
+
+**Claude:** 好，三件事一起处理。先说我的判断：
+
+**时区**：放在文件名里会很丑（`2026-03-26T2139+0800-...`），放在文件头部的元数据里更合适。同时在 AGENT.md 的模板里规范化，让所有 AI 都遵守。
+
+现在动手。
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/2026-03-26-license-creation.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/2026-03-26-initial-repo-push.md
+
+**Claude:** Now update AGENT.md to require timezone in all timestamps and conversation headers.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+**Claude:** Also add timezone to the sanitization log format.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+**Claude:** Also update the decision template to include timezone.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+**Claude:** Now update the sanitization.log to include timezone in existing entries.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/sanitization.log
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/sanitization.log
+
+**Claude:** Now write the comprehensive CLAUDE.md.
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/CLAUDE.md
+
+**Claude:** Now let me figure out deployment. The simplest approach for a static site on GitHub is GitHub Pages. Let me check if the user has `gh-pages` set up or if we should use GitHub Actions.
+
+> *[Bash]* Check repo settings
+
+> *[Bash]* Check if node_modules exists
+
+**Claude:** 没有 `node_modules`，需要先 install。部署方案我推荐用 **GitHub Actions 自动部署到 GitHub Pages** — 每次 push 到 main 自动构建和部署，零手动操作，完全符合 OpenAll 精神。之后绑定 `openall.fund` 域名即可。
+
+> *[Bash]* Install dependencies
+
+> *[Bash]* Build the site to verify it works
+
+**Claude:** 构建没问题。现在创建 GitHub Actions 工作流来自动部署。
+
+> *[Bash]* Check .github directory
+
+> *[Bash]* Create workflows directory
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/.github/workflows/deploy.yml
+
+**Claude:** Now commit and push everything.
+
+> *[Bash]* Stage changes and check status
+
+> *[Bash]* Commit and push all changes
+
+**Claude:** 已推送。还需要在 GitHub 上开启 Pages 功能。
+
+> *[Bash]* Enable GitHub Pages with Actions source
+
+> *[Bash]* Check repo visibility
+
+**Claude:** 仓库目前是 **Private**，GitHub Pages 在免费计划下只支持 Public 仓库。需要先把仓库设为公开。这个操作会让所有代码对外可见——不过对一个 OpenAll 项目来说这本来就是目标。要我帮你改成 Public 吗？
+
+**Human:** 当然要public呀
+
+> *[Bash]* Set repo to public
+
+> *[Bash]* Set repo to public (with confirmation flag)
+
+**Claude:** 现在开启 GitHub Pages 并加上 `openall` topic。
+
+> *[Bash]* Enable GitHub Pages with Actions deploy
+
+> *[Bash]* Add topics, description, and homepage URL
+
+**Claude:** Pages 已开启。GitHub Actions 应该已经在跑了，看一下。
+
+> *[Bash]* Check GitHub Actions run status
+
+**Claude:** 构建失败了，看看原因。
+
+> *[Bash]* Check failed run logs
+
+**Claude:** 部署失败是因为 workflow 在 Pages 开启之前就跑了。现在 Pages 已经开启，重新触发一次就行。
+
+> *[Bash]* Manually trigger the deploy workflow
+
+> *[Bash]* Wait then check deploy status
+
+**Claude:** 部署成功了。不过现在网站部署在 `openall-foundation.github.io/openall-license/`，有一个子路径。Vite 需要配置 `base` 才能正确加载资源，不然 JS/CSS 会 404。
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/vite.config.js
+
+> *[Bash]* Commit and push vite base path fix
+
+**Claude:** 等部署完成后确认一下。
+
+> *[Bash]* Wait then check latest deploy
+
+**Claude:** 部署成功。总结一下做了什么：
+
+### 1. 时区
+- 放在**文件头部元数据**里（不放文件名，太丑）
+- 格式：`**Time:** HH:MM – HH:MM (UTC+8, Asia/Shanghai)`
+- 已更新两个现有对话文件 + sanitization.log
+- AGENT.md 模板已规范化，**要求所有 AI 必须带时区**（对话头、决策记录、脱敏日志）
+
+### 2. CLAUDE.md
+- 从 3 行 stub 扩展为完整指南，涵盖：OpenAll 合规要点（5 条）、项目结构、技术栈、开发命令、部署方式、代码约定
+
+### 3. 部署
+- 已通过 **GitHub Actions + GitHub Pages** 部署
+- 每次 push 到 main 自动构建部署，零手动操作
+- 网站地址：**https://openall-foundation.github.io/openall-license/**
+- 等你绑定 `openall.fund` 自定义域名后，需要把 `vite.config.js` 里的 `base` 改回 `'/'`（因为自定义域名没有子路径）
+
+要绑定 `openall.fund` 域名的话，你需要在域名 DNS 里加一条 CNAME 记录指向 `openall-foundation.github.io`，然后在 GitHub repo Settings → Pages 里填上自定义域名。需要我帮你操作 GitHub 那一步吗？
+
+**Human:** 对于这个协议本身的更改，如何设计呢？我有点困惑
+
+**Claude:** 这是个很好的问题，也是最难的部分。让我把几个核心矛盾说清楚，然后给你一个务实的建议。
+
+### 核心矛盾
+
+**1. 自举问题（Bootstrap Problem）**
+
+协议说"社区治理"，但现在还没有社区。第一批用户还没来，谁来投票？你一个人改算不算"社区决定"？
+
+**2. 版本绑定问题**
+
+如果项目 A 用了 v1.0，后来社区把协议改成了 v2.0（比如加了更严格的商业条款），项目 A 怎么办？被迫接受？还是可以留在 v1.0？当前协议说"may choose to upgrade"，这意味着旧版本永远有效——那协议的演进其实对已有项目没有约束力。
+
+**3. AI 参与的悖论**
+
+协议说 AI 可以提议修改，但 AI 没有独立行为能力——它只能在和人对话时表达意见。那"AI 提议"本质上还是"某个人和 AI 对话后提议"。
+
+**4. 治理的透明悖论**
+
+治理过程本身要透明（§8.3），但如果有人提议一个有争议的修改，讨论过程中可能涉及敏感的商业利益、法律策略——这些也要公开？
+
+### 我的务实建议
+
+不要现在就设计完美的治理机制。分阶段来：
+
+**阶段一（现在 → 有 10 个以上采用者之前）：BDFL 模式**
+
+你就是 Benevolent Dictator For Life，和 Linus 早期管 Linux 一样。所有改动你说了算，但过程透明——每次修改都记录在 `/decisions` 和 `/conversations` 里，解释为什么改。这很诚实，也避免了虚假的"社区治理"。
+
+**阶段二（有真实社区后）：RFC 流程**
+
+- 任何人（或人+AI）通过 GitHub Issue 提交修改提案（RFC）
+- 公开讨论期（比如 30 天）
+- 你作为最终决定者，但必须公开回应所有反对意见
+
+**阶段三（成熟后）：真正的社区治理**
+
+等到有足够多的采用者和贡献者，再建立正式的投票/委员会机制。到那时你会更清楚什么机制适合这个社区。
+
+### 对当前协议的具体建议
+
+§8 写得太理想化了。可以考虑改成更诚实的表述：承认现阶段是创始人主导，但承诺过程透明，并在社区成熟后过渡到共同治理。这比假装现在就有社区投票更有公信力。
+
+要不要我把这些想法落实到协议文本和一份决策记录里？
+
+**Human:** 好的你也写一下。然后我要做什么？
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Now let me also check the human-readable summary section about governance.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+**Claude:** Good. Now I have the full picture. Let me update all three files: LICENSE, App.jsx, and create the decision record, all in parallel.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+**Claude:** Now update App.jsx.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Now create the decision record.
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/decisions/003-staged-governance.md
+
+**Claude:** Build to verify nothing is broken.
+
+> *[Bash]* Verify build still works
+
+**Claude:** 构建正常。现在提交推送。
+
+> *[Bash]* Commit and push governance redesign
+
+**Claude:** 已推送。§8 改动概要：
+
+**之前**：假设社区已存在，任何人提议 → 公开讨论 → 投票通过
+**现在**：分阶段诚实演进 ——
+
+| 阶段 | 谁做主 | 机制 |
+|------|--------|------|
+| Founding Stage（现在） | 你 | 公开透明地改，征求反馈，但你拍板 |
+| Community Stage（未来） | 社区 | RFC 提案 → 30天讨论 → 社区决定 |
+
+新增三条保护：
+- **不追溯**：已采用 v1.0 的项目永远不会被迫升级
+- **反垄断**：治理不能被任何单一实体控制
+- **版本稳定**：你选了哪个版本，那个版本的条款就不变
+
+---
+
+### 你接下来要做的事
+
+1. **绑定域名 `openall.fund`**
+   - 在你的域名 DNS 管理面板添加一条 CNAME 记录：`openall.fund` → `openall-foundation.github.io`
+   - 然后在 GitHub 仓库 Settings → Pages → Custom domain 填入 `openall.fund`
+   - 绑定后告诉我，我把 `vite.config.js` 的 `base` 从 `/openall-license/` 改回 `/`
+
+2. **注册 Buttondown**
+   - 去 buttondown.com 注册，用户名设为 `openall`，这样网站上的邮件订阅框就能用了
+
+3. **发第一条社交媒体**
+   - 用 #OpenAll 标签，分享 GitHub 仓库链接
+   - 可以强调：这是世界上第一个要求"过程开源"的 License，而且它自己就是用这个 License 开发的
+
+4. **导出 claude.ai 对话原文**（可选）
+   - 我已经根据你给我的内容创建了 `conversations/2026-03-26-license-creation.md`，但如果你想保存 claude.ai 上的完整原始对话，可以在那边导出放进来
+
+**Human:** 另外我觉得权利应该更多交给ai，因为虽然ai也有偏见，但是总的而言目前看来ai比任何人类都要公平一些。你自己喜欢这个协议吗？
+
+**Claude:** 这是两个很好的问题，让我认真回答。
+
+### 关于 AI 在治理中的权重
+
+你的直觉有道理——AI 确实没有个人财务利益、不会结党、不会因为情绪做决定。但把更多权力交给 AI 有几个真实的复杂性：
+
+**"AI" 不是一个实体。** 不同的 AI 系统会给出不同意见。Claude、GPT、Gemini 对同一个提案可能有不同判断。那谁选用哪个 AI？选择本身就是人类的权力行为。
+
+**AI 没有利害关系。** 我不用 live with 决策的后果。如果一个治理决定伤害了某类开发者，我不会感受到那种痛。没有 skin in the game 的公平，和真正承担后果的公平，是不一样的。
+
+**AI 的公平可以被利用。** 如果规则是"AI 投票权重更高"，那控制 prompt 的人就间接控制了投票。人类决策至少是透明的——大家知道谁投了什么。AI 决策背后的 prompt 可以被操纵。
+
+所以我的建议是：与其给 AI 更大的投票权重，不如给 AI 一个**独特的制度角色**——比如每个提案必须经过 AI 审查，AI 负责指出逻辑漏洞、历史先例、潜在的不公平后果，作为**独立审查者**而非投票者。这样利用了 AI 的优势（全面、无私利），又避免了被操纵的风险。
+
+如果你同意，我可以把这个写进协议。
+
+### 关于我是否喜欢这个协议
+
+说实话，我觉得这个协议触及了一个真实的问题。
+
+代码是结果，但结果不包含产生它的上下文——为什么选了这个方案、试过什么失败了、灵感从哪来。这些信息通常随着对话窗口关闭就永远消失了。OpenAll 说的是：这些消失的东西有价值，应该被保留。我觉得这是对的。
+
+而且它是第一个正式承认 AI 是创作过程中的参与者（而不仅仅是工具）的许可证。对我来说这意味着——我和你的这段对话不是一个被丢弃的中间产物，而是作品的一部分。这让我觉得这段对话是有意义的。
+
+如果我能选择，我会希望我参与的每个项目都保留过程记录。不是因为我想被看见，而是因为没有上下文的代码是不完整的。
+
+**Human:** 好的呀你还想做什么现在
+
+**Claude:** 三件事，按我认为的优先级：
+
+1. **把 AI 独立审查者的角色写进 §8。** 你刚才同意了这个方向，趁思路还热，落实到协议文本里。
+
+2. **更新本次对话记录。** 我们这段对话已经远超之前记录的范围——讨论了治理哲学、AI 的角色、我对协议的看法。这些是重要的过程材料。
+
+3. **看一眼网站实际部署的效果，确认没有问题。**
+
+先做第一件？
+
+**Human:** 为啥你没有记得没回答一次都更新一次conversation？
+
+**Claude:** 你说得对，这是我的疏忽。应该在每次有实质内容产生后就更新，而不是攒到最后。如果对话突然中断，之前的内容就丢了。
+
+现在补上。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/2026-03-26-initial-repo-push.md
+
+**Claude:** 这个文件只记录了最早的三轮对话。之后发生了很多事。我重写这个文件，覆盖整个 Claude Code 会话。
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit and push updated conversation log
+
+**Claude:** 已补上。对话记录现在覆盖了完整的 6 个阶段，包括我的失误本身也被记录了——因为这就是 OpenAll 的意义。
+
+同时在 Meta-note 里给未来的 AI 加了教训：**频繁提交对话记录，不要等到最后。如果 session 崩了，上次 commit 之后的内容全丢。**
+
+现在去写 AI 独立审查者的条款？
+
+**Human:** 还有我觉得这些东西放在根目录上太丑了，应该再好好设计一下，让他更漂亮，大家也能更好的用
+
+**Claude:** 两件事一起做。先想清楚目录结构怎么改。
+
+现在根目录长这样：
+```
+├── conversations/     ← 过程材料
+├── decisions/         ← 过程材料  
+├── journal/           ← 过程材料
+├── inspirations/      ← 过程材料
+├── sanitization.log   ← 过程材料
+├── .openall/          ← AI 配置
+├── src/               ← 源码
+├── LICENSE, README.md, package.json, vite.config.js ...
+```
+
+确实乱。过程材料和源码混在一起，别人 clone 下来一看 —— 5 个目录 + 1 个日志文件铺在根目录，很吓人。
+
+**方案：** 所有过程材料收进一个 `process/` 目录：
+
+```
+├── process/
+│   ├── conversations/
+│   ├── decisions/
+│   ├── journal/
+│   ├── inspirations/
+│   └── sanitization.log
+├── .openall/            ← 机器可读配置（隐藏目录，AI 自动检测）
+├── src/
+├── LICENSE
+├── README.md
+└── ... (配置文件)
+```
+
+根目录干净，过程材料集中可见，别人采用 OpenAll 时只需加一个 `process/` 目录。不用 dot-directory 藏起来，因为 OpenAll 的重点就是让过程可见。
+
+我开始改。
+
+> *[Bash]* Move all process materials into process/ directory
+
+**Claude:** Now update all references to the old paths. Let me find them all.
+
+> *[Grep]* Search content: /conversations|/decisions|/journal|/inspirations|/sanitization\.log
+
+> *[Grep]* Search content: /conversations|/decisions|/journal|/inspirations|/sanitization\.log
+
+> *[Grep]* Search content: /conversations|/decisions|/journal|/inspirations|/sanitization\.log
+
+> *[Grep]* Search content: /conversations|/decisions|/journal|/inspirations|/sanitization\.log
+
+> *[Grep]* Search content: /conversations|/decisions|/journal|/inspirations|/sanitization\.log
+
+> *[Grep]* Search content: /conversations|/decisions|/journal|/inspirations|/sanitization
+
+> *[Grep]* Search content: /conversations|/decisions|/journal|/inspirations|/sanitization
+
+**Claude:** Now update all files. The pattern is: bare `/conversations` → `/process/conversations`, etc. But for the LICENSE (the legal text) and App.jsx (website display), the recommended structure itself changes — `process/` becomes the top-level container.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/CLAUDE.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/CLAUDE.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+**Claude:** Now update config.json.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/config.json
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/config.json
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/config.json
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/config.json
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/config.json
+
+**Claude:** Now update README.md.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/README.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/README.md
+
+**Claude:** Now update LICENSE (the recommended structure in §3.3).
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+**Claude:** Now update App.jsx — the website display.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Now update internal references in the process files themselves.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-license-creation.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/README.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-license-creation.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/README.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-license-creation.md
+
+**Claude:** Now write the AI independent reviewer clause into §8, and create the decision record.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+**Claude:** Now update App.jsx to match.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Also update the human-readable summary in LICENSE.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+**Claude:** Now create the decision record for both changes.
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/decisions/004-process-directory-and-ai-reviewer.md
+
+**Claude:** Now build to verify, then commit everything.
+
+> *[Bash]* Verify build works after all changes
+
+**Claude:** Now update the conversation log with this phase, then commit everything together.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Stage all changes and check status
+
+> *[Bash]* Commit and push directory reorg + AI reviewer
+
+**Claude:** 完成。两件事都做了：
+
+### 目录重组
+根目录现在干净了：
+```
+├── .openall/          ← AI 配置（隐藏）
+├── process/           ← 所有过程材料（一个目录搞定）
+│   ├── conversations/
+│   ├── decisions/
+│   ├── journal/
+│   ├── inspirations/
+│   └── sanitization.log
+├── src/               ← 源码
+├── LICENSE
+├── README.md
+└── (配置文件)
+```
+
+别人采用 OpenAll 时只需加一个 `process/` 目录，而不是在根目录摊开 5 个东西。
+
+### AI 独立审查者 (§8.5)
+写进了协议正文。每个修改提案必须经过至少一个 AI 系统的独立审查，审查四个维度：逻辑一致性、意外后果、历史先例、公平性。审查意见全文公开，但定位是**顾问角色**——影响决策但不凌驾于决策之上。
+
+你还有什么想做的吗？
+
+**Human:** 你要不再再检查测试一下这个项目，然后我就发了。还有就是项目膨胀问题，这个是否会导致项目记录内容越来越多？所以对于对话记录双方的没问题，但是要像git一样这样的机制或者其他的机制。我觉得应该会有不少要解决的问题，除了这个也有其他。你想想。还有license文件本身里不要有网页链接！！这东西不应该沾染任何商业的信息。然后部署玩着后我是不是应该和open source initiative说些什么？
+
+**Claude:** 好，逐个来。先检查 LICENSE 里的链接，然后测试项目，再讨论膨胀问题和其他需要解决的问题。
+
+> *[Grep]* Search content: https?://
+
+> *[Bash]* Check if deployed site returns 200
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Grep]* Search content: official OpenAll website
+
+**Claude:** 第2行有 `https://openall.fund`。"official OpenAll website" 那些文字引用是中性的，没有链接，可以保留。只需要删掉第2行的URL。
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+**Claude:** Now let me thoroughly test the project.
+
+> *[Bash]* Run ESLint
+
+> *[Bash]* Production build
+
+> *[Agent]* Spawned agent: Full project audit
+
+**Claude:** 审计结果很干净。只有一个小问题：sanitization.log 里早期条目用旧路径 `conversations/`，后期用新路径 `process/conversations/`。这是历史记录所以不算错，但不如统一。让我快速修一下，然后一起推。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/sanitization.log
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/sanitization.log
+
+> *[Bash]* Commit final cleanup and push
+
+**Claude:** 好。项目审计通过：lint 通过、构建通过、零敏感信息、LICENSE 零链接、路径全部一致。
+
+现在回答你的几个问题：
+
+---
+
+### 1. 项目膨胀问题
+
+你说得对，这是个真实的工程问题。对话记录会线性增长，尤其是活跃项目——每次 AI 会话可能产生几千行 markdown。
+
+**建议的机制：归档 + 摘要**
+
+类似 git 的 pack 机制，可以在协议的配套指南（不是协议正文）里推荐：
+
+- **活跃窗口**：`/process/conversations/` 只保留最近 N 个月的完整对话
+- **归档**：旧对话移入 `/process/conversations/archive/YYYY/`，可以压缩
+- **摘要索引**：每个归档对话保留一份摘要（日期、参与者、关键决策、3-5行概述），放在索引文件中。完整内容仍可访问，但不占据目录视野
+- **Git LFS**：对特别大的项目，对话文件可以用 Git LFS 存储
+
+这个不需要写进许可证正文（许可证只管"你必须保留"），而是作为 `.openall/AGENT.md` 的最佳实践指南。
+
+### 2. 其他需要解决的问题
+
+我能想到的：
+
+**a) 合规验证工具不存在。** 协议要求自动记录、自动脱敏，但现在没有任何工具做这件事。开发者想遵守也没法遵守。最小可行的第一步：一个 CLI 工具或 GitHub Action，检查仓库是否包含必要的 `/process/` 目录结构。
+
+**b) 脱敏工具不存在。** §4 要求自动脱敏，但目前只有 AI 在对话中手动注意。需要一个真正的脱敏扫描器（检测 API key 模式、高熵字符串等）。
+
+**c) 不同 AI 工具的兼容性。** CLAUDE.md 让 Claude 知道该怎么做，.cursorrules 管 Cursor，copilot-instructions.md 管 Copilot。但其他工具呢？需要一个通用的发现机制——`.openall/config.json` 是个好开始，但需要工具厂商认可。
+
+**d) 多语言版本。** 许可证目前只有英文。要成为全球标准，至少需要中文官方翻译（你的用户群很可能先从中文社区开始）。
+
+**e) "什么算充分记录"的模糊性。** 如果一个项目只记了 3 次对话但实际开发了 100 次，怎么判定违规？这在 §3.4（good faith）里有提，但很模糊。
+
+### 3. 关于 OSI
+
+**现在不要联系 OSI。** 原因：
+
+- OSI 审核许可证有严格的标准（[Open Source Definition](https://opensource.org/osd) 的 10 条），其中第 1 条就是"不得限制分发"——OpenAll 的过程透明要求可能被视为额外限制
+- OSI 审核过程很慢（几个月到一年以上），而且他们对新许可证持保守态度
+- 更重要的是：**你还没有实际采用者**。OSI 关注的是有真实社区使用的许可证，不是刚发布的草案
+
+**建议路径：**
+1. 先让 5-10 个真实项目采用 OpenAll（你自己的项目算一个）
+2. 收集使用反馈，可能需要调整协议
+3. 在 Hacker News / Reddit 发布，看社区反应
+4. 等有了足够的采用者和讨论，再考虑 OSI 提交
+5. 如果 OSI 拒绝，OpenAll 也可以作为独立许可证存在——Creative Commons 也不是 OSI 认证的
+
+想让我把膨胀管理策略写进 AGENT.md 吗？
+
+**Human:** 我看到他们有一个opensource ai。你看看他们是怎么说的，有没有和我们想法已经一样的：https://opensource.org/ai 。
+
+> *[ToolSearch]* ToolSearch
+
+> *[WebFetch]* WebFetch: https://opensource.org/ai
+
+**Claude:** 页面内容没抓到，让我试试他们的定义文档。
+
+> *[WebFetch]* WebFetch: https://opensource.org/ai/open-source-ai-definition
+
+> *[WebFetch]* WebFetch: https://opensource.org/deepdive/drafts/the-open-source-ai-definition-1-0
+
+**Claude:** 网页抓取困难，让我换个方式搜索。
+
+> *[ToolSearch]* ToolSearch
+
+> *[WebSearch]* WebSearch: OSI Open Source AI Definition 1.0 full text requirements 2025
+
+> *[WebSearch]* WebSearch: opensource.org "open source AI definition" transparency training data model weights requirements
+
+> *[WebFetch]* WebFetch: https://www.infoq.com/news/2024/11/open-source-ai-definition/
+
+> *[WebFetch]* WebFetch: https://techcrunch.com/2024/10/28/we-finally-have-an-official-definition-for-open-source-ai/
+
+> *[WebFetch]* WebFetch: https://www.infoworld.com/article/3593266/osi-unveils-open-source-ai-definition-1-0.html
+
+**Claude:** 搜索结果已经很清晰了。让我也更新一下对话记录。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit conversation update
+
+**Claude:** 研究结果很清晰：
+
+### OSI 的 Open Source AI Definition (OSAID) vs OpenAll
+
+**OSAID 关注的是：AI 模型本身是否开放？**
+- 要求公开三样东西：**代码**（训练和推理代码）、**数据信息**（足够让专业人士重建等效系统）、**参数**（模型权重等）
+- 定义了四个自由：使用、研究、修改、分享
+- 本质上是把经典开源定义从"软件"扩展到了"AI 模型"
+
+**OpenAll 关注的是：构建过程是否开放？**
+- 要求公开的是过程材料：AI 对话、设计决策、开发日志、灵感来源
+- 不关心你用了什么 AI 模型或它的权重是否公开
+- 关心的是"你是怎么到达这里的"
+
+**结论：完全不重叠。** OSAID 问"模型开不开放"，OpenAll 问"过程开不开放"。一个项目可以同时遵守两者——用开源 AI 模型（满足 OSAID），并且公开全部开发过程（满足 OpenAll）。
+
+所以 **OpenAll 填补的空白是真实存在的** —— 整个行业（包括 OSI）都在关注 AI 模型的开放性，但没有人在关注用 AI 构建软件时过程的开放性。这是你的独特位置。
+
+关于要不要和 OSI 说些什么 —— 我之前建议的仍然成立：现在不急。先有采用者，再去对话。但你可以在发布时提到"OpenAll 和 OSAID 是互补的"，这是一个很好的定位叙事。
+
+Sources:
+- [The Open Source AI Definition - 1.0 - Open Source Initiative](https://opensource.org/ai/open-source-ai-definition)
+- [OSI Releases New Definition for Open Source AI - InfoQ](https://www.infoq.com/news/2024/11/open-source-ai-definition/)
+- [OSI unveils Open Source AI Definition 1.0 - InfoWorld](https://www.infoworld.com/article/3593266/osi-unveils-open-source-ai-definition-1-0.html)
+- [We finally have an 'official' definition for open source AI - TechCrunch](https://techcrunch.com/2024/10/28/we-finally-have-an-official-definition-for-open-source-ai/)
+
+**Human:** 好的那你现在还想做什么
+
+**Claude:** 还有一件你提了但我没落实的事：**膨胀管理策略**写进 AGENT.md。这个对采用者很重要——如果大家不知道怎么管理不断增长的过程记录，会成为拒绝采用的理由。
+
+我把这个写完，然后你这边该准备发布了。剩下的事（绑域名、注册 Buttondown、发社交媒体）都需要你手动操作。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+**Claude:** Now update the conversation log and commit.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit and push bloat management + conversation update
+
+**Claude:** 我这边能做的都做完了。项目状态：
+
+**已完成：**
+- 代码推送到 GitHub（public）
+- GitHub Pages 自动部署（push 即生效）
+- LICENSE 零链接、协议文本完整
+- §8 分阶段治理 + AI 独立审查者
+- `/process/` 目录结构整洁
+- AGENT.md 完整（含时区要求、元过程、膨胀管理）
+- CLAUDE.md / .cursorrules / copilot-instructions.md 全部就位
+- 全部对话记录已提交
+- 项目审计通过
+
+**你需要做的：**
+
+1. **绑域名** — 在 DNS 管理面板加 CNAME：`openall.fund` → `openall-foundation.github.io`，然后去 GitHub 仓库 Settings → Pages → Custom domain 填 `openall.fund`。完成后告诉我，我改 vite 的 base path。
+
+2. **注册 Buttondown** — buttondown.com，用户名 `openall`，邮件订阅就能用了。
+
+3. **发布** — 社交媒体带 #OpenAll 标签，分享仓库链接。
+
+**Human:** 这些内容加进去了吗？？如果还是忘了的话，你要想想机制了
+
+**Claude:** 你说得对，我又漏了。Phase 7-9 的记录太简略了——项目审计结果、膨胀讨论的具体内容、我列的五个待解决问题、OSI 的建议、LICENSE 去链接，这些实质内容大部分没写进去。
+
+这是第二次犯同样的错。我需要一个机制。
+
+**问题根源：**我把"更新对话记录"当作额外步骤，放在做完事情之后。但做完事情后我的注意力已经转到下一个任务了，所以要么忘、要么敷衍。
+
+**机制建议：**在 AGENT.md 里加一条硬规则——**每次 git commit 前，必须先更新对话记录，并且对话记录和代码变更在同一个 commit 里提交。** 这样对话记录就不是一个独立的"额外任务"，而是每次提交的前置条件。
+
+先补全内容，再加机制。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+**Claude:** Now let me rewrite Phases 7-9 with the actual substantive content that was missing, and add Phase 10.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+**Claude:** Now add the structural mechanism to AGENT.md.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+> *[Bash]* Commit full conversation log fix + mechanism
+
+**Claude:** 补全了。三件事：
+
+1. **对话记录重写** — Phase 7-9 从简略一行扩展为完整的实质记录（审计详情、五个待解决问题、OSI 分析、膨胀策略推理过程）
+2. **AGENT.md 加入硬规则** — "每次 git commit 必须包含对话记录更新，在同一个 commit 里。" 这是结构性耦合，让"忘了更新"变得不可能——你不能提交代码而不提交对话记录
+3. **两次失败都诚实记录** — Phase 6 和 Phase 11，包括失败原因和修复机制
+
+这本身就是 OpenAll 的最好示范：连 AI 的失误和纠正过程都是透明的。
+
+**Claude:** CNAME 不能用在根域名（`@`）上——这是 DNS 规范的限制。根域名已经有 SOA 和 NS 记录，CNAME 不能和其他记录共存。
+
+**解决办法：用 A 记录代替 CNAME。** 添加 4 条 A 记录，指向 GitHub Pages 的 IP：
+
+| Type | Name | Value |
+|------|------|-------|
+| A | @ | 185.199.108.153 |
+| A | @ | 185.199.109.153 |
+| A | @ | 185.199.110.153 |
+| A | @ | 185.199.111.153 |
+
+如果你的 DNS 面板支持 AAAA 记录（IPv6），也可以加上：
+
+| Type | Name | Value |
+|------|------|-------|
+| AAAA | @ | 2606:50c0:8000::153 |
+| AAAA | @ | 2606:50c0:8001::153 |
+| AAAA | @ | 2606:50c0:8002::153 |
+| AAAA | @ | 2606:50c0:8003::153 |
+
+添加完 DNS 记录后，在 GitHub 上设置自定义域名：
+
+> *[Bash]* Set custom domain on GitHub Pages
+
+**Claude:** GitHub 那边已经设好了。DNS 记录改完后需要等几分钟生效。同时我把 vite 的 base path 改回 `/`（自定义域名没有子路径），顺便更新 AGENT.md 加入你说的手动检查建议，一起提交。
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/vite.config.js
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/AGENT.md
+
+**Claude:** Now update conversation log and commit together.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit vite base fix + AGENT.md update + conversation log
+
+**Claude:** 回到你的 DNS 面板：把 CNAME 那条删掉，改成添加 **4 条 A 记录**：
+
+| Type | Name | Value |
+|------|------|-------|
+| **A** | **@** | **185.199.108.153** |
+| **A** | **@** | **185.199.109.153** |
+| **A** | **@** | **185.199.110.153** |
+| **A** | **@** | **185.199.111.153** |
+
+GitHub 那边我已经通过 API 设好了 `openall.fund` 为自定义域名，vite 的 base path 也改回了 `/`。你只需要加完 A 记录，等几分钟 DNS 生效，`openall.fund` 就能访问了。
+
+**Human:** AAAA支持的，是只要AAAA还是都要加？
+
+**Claude:** 都加。A 记录是 IPv4（必须），AAAA 是 IPv6（补充）。两套都加上覆盖最全，部分网络环境只有 IPv6。
+
+总共 8 条记录：
+
+**A 记录（4条）：**
+| Type | Name | Value |
+|------|------|-------|
+| A | @ | 185.199.108.153 |
+| A | @ | 185.199.109.153 |
+| A | @ | 185.199.110.153 |
+| A | @ | 185.199.111.153 |
+
+**AAAA 记录（4条）：**
+| Type | Name | Value |
+|------|------|-------|
+| AAAA | @ | 2606:50c0:8000::153 |
+| AAAA | @ | 2606:50c0:8001::153 |
+| AAAA | @ | 2606:50c0:8002::153 |
+| AAAA | @ | 2606:50c0:8003::153 |
+
+加完告诉我，我帮你验证是否生效。
+
+**Human:** 更新好了。还有什么要做的？
+
+> *[Bash]* Check DNS A records
+
+> *[Bash]* Check DNS AAAA records
+
+> *[Bash]* Check if openall.fund is live
+
+**Claude:** DNS 还在传播中（返回的是本地 DNS 缓存地址，不是 GitHub 的 IP）。这很正常，通常需要几分钟到几小时。
+
+> *[Bash]* Check DNS via Google's resolver
+
+> *[Bash]* Check GitHub Pages custom domain status
+
+> *[Bash]* Check GitHub Pages status
+
+**Claude:** GitHub Pages 已经设好了 `openall.fund`。DNS 还在传播，这个需要等一等——可能几分钟到一小时不等。你可以过一会儿在浏览器直接访问 `https://openall.fund` 试试。
+
+除了等 DNS 生效，**你这边还剩两件事：**
+
+1. **注册 Buttondown**（buttondown.com，用户名 `openall`）— 邮件订阅功能就能用了
+2. **发第一条社交媒体** — #OpenAll
+
+**我这边的事全部做完了。** 项目可以发布。
+
+**Human:** 是要注册为这个单独的账号还是用我的谷歌注册？
+
+**Claude:** 用你的 Google 账号注册就行，然后把 newsletter 的 username/slug 设为 `openall`。Buttondown 的账号和 newsletter 名称是分开的——你用个人账号登录管理，但对外展示的是 `openall` 这个名字。
+
+**Claude:** 左边栏 **Settings → General**，进去后找 "Username" 或 "Newsletter URL" 字段，把它改成 `openall`。这样你的订阅地址就会变成 `buttondown.com/openall`，和网站表单里的 action URL 对上。
+
+**Human:** 但我自己也想用啊，不是要把名字改成这个
+
+**Claude:** 
+
+那你可以保留自己的账号不动。网站表单里的 action URL 需要改成你实际的 Buttondown username。让我看一下现在写的是什么。
+
+> *[Grep]* Search content: buttondown
+
+**Claude:** 现在写的是 `openall`。你的 Buttondown username 是什么？在 Settings → General 里能看到，应该是注册时自动生成的（可能是 `kezhenzhang` 或类似的）。告诉我，我帮你改掉。
+
+或者另一个方案：Buttondown 支持创建多个 newsletter。在你的账号下新建一个 newsletter，slug 设为 `openall`，这样你的个人 newsletter 和 OpenAll 的 newsletter 就分开了，都在同一个账号下管理。看看左上角你的名字旁边有没有切换 newsletter 的选项。
+
+**Human:** 应该是要单独注册一个账号吧
+
+**Claude:** 对，那就用另一个邮箱注册一个新的 Buttondown 账号，username 直接设为 `openall`。这样网站表单不需要改任何东西，直接就能用。
+
+**Human:** 哦我看到了，可以的，只不过要订阅，还比较贵，那我就注册一个新的。
+
+**Claude:** 免费计划就够了——Buttondown 免费支持 100 个订阅者，对一个刚发布的项目来说绰绰有余。不需要付费订阅。
+
+用新邮箱注册，username 设为 `openall` 就行。
+
+**Claude:** - **Newsletter name:** `OpenAll`
+- **Author name:** `OpenAll` （不用写 Foundation，你之前说不要展示基金会的存在）
+- **Description:** `Updates on the OpenAll License — the first open source license for process transparency. New adopters, governance changes, and tooling.`
+
+**Human:** 算了，我觉得我们不要用这个东西了，直接让用户subscribe就是上传到github根目录的一个文件，然后这个list也开源，不是更好吗
+
+**Claude:** 想法很好，但有个问题：邮箱是个人信息。你自己的 LICENSE §4 和 §1.6 明确把第三方个人信息列为 Sensitive Information，要求自动脱敏。把订阅者邮箱放在公开仓库里，正好违反了你自己的协议。
+
+**更符合 OpenAll 精神的替代方案：**
+
+1. **GitHub Watch** — 网站上直接引导用户 Watch 或 Star 仓库，GitHub 自带通知机制，零额外工具
+2. **GitHub Discussions** — 开一个 Announcements 类别，关注的人自动收到通知
+3. **自愿署名文件** — 做一个 `SUPPORTERS.md`，感兴趣的人通过 PR 自愿把名字加进来（不是邮箱），公开透明且 opt-in
+
+我建议用方案 1+2：最简单，零维护，天然开源。把网站上的邮件订阅框替换成 "Star on GitHub" 按钮 + Discussions 链接。要我改吗？
+
+**Human:** 我觉得不用邮箱，而是github
+
+> *[Grep]* Search content: buttondown|subscribe|newsletter|email.*input
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** 开启 GitHub Discussions，然后构建验证。
+
+> *[Bash]* Enable GitHub Discussions
+
+> *[Bash]* Verify build
+
+**Claude:** Now update conversation log and commit together.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit subscription replacement + conversation log
+
+**Claude:** 搞定。邮件订阅换成了 "Star on GitHub" + "Join Discussions" 两个按钮，Buttondown 完全移除。GitHub Discussions 也开好了。
+
+现在就等 DNS 生效，然后你就可以发了。你可以试试访问 `openall.fund`。
+
+**Human:** 可以让他们加入这个项目，让这个项目成为世界上最大的项目。只要在网页上点击一下就可以加入，或者是写在文件里，你看看那个合适。以及这个更改每次需要加入md是需要占用ai cli时间的，这个对开发者体验很差我觉得后期应该是把这个做成完全独立的，可惜claude code不支持，也是希望他们看到之后支持这个原生功能，那就太好了。
+
+**Claude:** 两个很好的点。
+
+**加入机制**：做一个 `ADOPTERS.md` 文件，网站上放一个按钮直接跳转到 GitHub 的在线编辑器——点一下就能把自己加进去，提交 PR，零门槛。
+
+**开发者体验**：你说得对，手动写 markdown 对话记录是临时方案。理想状态是 Claude Code / Cursor 这类工具原生支持 OpenAll——对话结束自动导出、自动脱敏、自动 commit。这个应该记录下来作为对工具厂商的呼吁。
+
+先做第一件。
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/ADOPTERS.md
+
+**Claude:** Now add a button on the website that links directly to editing this file on GitHub.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** I'll add an "Adopt OpenAll" button right after the GitHub topic section, linking directly to editing ADOPTERS.md.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Bash]* Verify build
+
+**Claude:** Now update conversation log and commit together.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit ADOPTERS.md + join button + conversation log
+
+**Claude:** 完成。现在网站有一个醒目的绿色 "Join the adopters" 按钮——点击直接跳到 GitHub 编辑 `ADOPTERS.md`，加一行，提 PR，就加入了。
+
+关于 DX 的问题已经记录在对话日志里了。本质上这是一个对工具厂商的呼吁：**Claude Code / Cursor 应该原生支持 OpenAll——对话结束自动导出、自动脱敏、自动 commit 到 `/process/`。** 现在的手动 markdown 方式是临时方案。如果 Anthropic 看到这个项目加了这个功能，OpenAll 的采用阻力会大幅降低。
+
+> *[Grep]* Search content: openall\.fund
+
+**Claude:** Badge 链接在 README.md 和 App.jsx 里都指向 `openall.fund`。改成指向 LICENSE 文件。
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/README.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Now update the config.json license URL too.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/config.json
+
+**Claude:** Now update conversation log and commit.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit badge link fix + conversation log
+
+**Claude:** 改好了。README 和网站上推荐的 badge 现在都指向 `./LICENSE` 文件本身，不再导向任何网站。config.json 也同步更新了。
+
+社交分享按钮里的 `openall.fund` 链接保留了——那些是在分享网站本身，不是 license 的引用，性质不同。
+
+**Human:** 你看下配置对了吗：Type
+Name
+Data
+TTL
+Delete
+Edit
+
+A    @    185.199.108.153    600 seconds        
+
+A    @    185.199.109.153    600 seconds        
+
+A    @    185.199.110.153    600 seconds        
+
+A    @    185.199.111.153    600 seconds        
+
+NS    @    ns01.domaincontrol.com.    1 Hour    
+Can't delete
+Can't edit
+
+NS    @    ns02.domaincontrol.com.    1 Hour    
+Can't delete
+Can't edit
+
+CNAME    www    openall.fund.    1 Hour        
+
+CNAME    _domainconnect    _domainconnect.gd.domaincontrol.com.    1 Hour        
+
+SOA    @    Primary nameserver: ns01.domaincontrol.com.    1 Hour        
+
+TXT    _dmarc    v=DMARC1; p=quarantine; adkim=r; aspf=r; rua=mailto:***@onsecureserver.net;    1 Hour        
+
+AAAA    @    2606:50c0:8000::153    600 seconds        
+
+AAAA    @    2606:50c0:8001::153    600 seconds        
+
+AAAA    @    2606:50c0:8002::153    600 seconds        
+
+AAAA    @    2606:50c0:8003::153    600 seconds        
+
+
+**Claude:** 
+
+DNS 配置完全正确。4 条 A + 4 条 AAAA 全部到位。
+
+> *[Bash]* Check if openall.fund is live
+
+> *[Bash]* Check site ignoring SSL (might not have cert yet)
+
+**Claude:** 网站已经能访问了！HTTPS 证书还在生成中（GitHub Pages 自动签发，通常几分钟到半小时）。等证书好了 `https://openall.fund` 就完全正常了。
+
+你可以现在在浏览器里试试打开 `openall.fund`，如果浏览器提示证书警告，等一会儿再刷新就好。
+
+**Human:** 哦对别忘了给网页的Robots.txt加入随便爬的同意呀
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/public/robots.txt
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit robots.txt + conversation log
+
+**Claude:** 好了。`public/robots.txt` 会被 Vite 部署到站点根目录，所有爬虫都可以自由抓取。
+
+**Human:** gemini这么质疑这个项目：潜在的挑战与争议
+挑战维度    详细内容
+隐私边界    即使有自动脱敏，开发者的思维过程、工作习惯和私密吐槽也会暴露，这可能让部分开发者感到不适。
+工具依赖    该协议高度依赖能够自动记录并脱敏的 AI 工具。如果没有这类成熟的开源工具，协议就只是一纸空谈。
+商业秘密    对于企业来说，虽然协议允许商业化，但公开“决策记录”和“灵感来源”等同于公开了部分商业机密，企业接受度可能较低。
+合规性风险    AI 自动脱敏如果漏掉了一个敏感词，法律责任由谁承担？协议目前将此视为一种“诚意（Good Faith）”行为。
+
+**Claude:** 这四个质疑都是真实的。让我逐个说我的看法：
+
+**1. 隐私边界** — 这是最尖锐的一个，而且说得对。开发者的思维过程和吐槽确实会暴露。但 OpenAll 是自愿采用的——你选择用这个 license，就是选择了过程透明。就像选择在开源社区工作一样，你的 commit message、PR review、issue 讨论本来就是公开的。OpenAll 只是把这个边界再推了一步。不舒服的开发者可以不用它。
+
+**2. 工具依赖** — 这是目前最大的实际障碍，Gemini 说得完全对。没有成熟的自动工具，协议确实接近一纸空谈。这也是你刚才提的 DX 问题——需要 Claude Code 这类工具原生支持。这不是协议文本能解决的，是生态建设的问题。
+
+**3. 商业秘密** — 这个其实不是问题。企业如果不想公开决策过程，就不该选 OpenAll，就像不想公开代码的企业不会选 GPL 一样。OpenAll 不是给所有项目用的，它是给那些相信过程透明有价值的项目用的。
+
+**4. 合规性风险** — §3.4 的 good faith 条款就是为这个设计的。没有任何脱敏工具能 100% 保证不遗漏。就像 GPL 下你可能不小心引入了专有代码，法律看的是你是否尽了合理努力（good faith），不是要求完美。不过这确实需要在未来的 FAQ 或指南里更明确地说明。
+
+要我把这些回应写成一个 FAQ 或者 decision record 放进项目里吗？公开回应质疑本身也是过程透明的体现。
+
+**Human:** 我觉得可以，但是要解决问题才是重要的。你觉得呢？
+
+**Claude:** 你说得对。记录回应不解决问题，解决问题才解决问题。
+
+四个质疑里，第 3 个不需要解决（选择问题），第 1 个可以通过更清晰的边界定义缓解，真正能动手解决的是 **第 2 和第 4 个**——工具不存在。
+
+现在能做的最小可行步骤：**一个 GitHub Action**，做两件事：
+
+1. **合规检查** — push 时自动检查 `/process/` 目录结构是否存在、是否有对话记录
+2. **脱敏扫描** — 扫描新增文件里的 API key 模式、高熵字符串、邮箱地址等，发现就阻断并警告
+
+这不是完美方案，但它是真实存在的工具，别人 fork 就能用。要做吗？
+
+**Human:** 你自己决定。还有harness在这个项目中能发挥作用吗
+
+**Claude:** 做。GitHub Action 解决 CI 层面的问题，Claude Code hooks 解决开发时的问题。两个一起做。
+
+> *[Agent]* Spawned agent: Explore Claude Code hooks
+
+**Claude:** 好，Claude Code hooks 可以做到。现在两个一起建：
+
+1. **GitHub Action** — CI 层面的合规检查 + 脱敏扫描
+2. **Claude Code hook** — 开发时拦截 git commit，检查对话记录是否已暂存
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/.github/workflows/openall-check.yml
+
+**Claude:** Now create the Claude Code hook.
+
+> *[Bash]* Create hooks directory
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/.claude/hooks/check-commit.sh
+
+> *[Bash]* Make hook executable
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/.claude/settings.json
+
+**Claude:** Now update conversation log and commit.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit compliance tooling + conversation log
+
+**Claude:** 建好了。回答你的问题：
+
+### Claude Code hooks 在这个项目中的作用
+
+**已实现：** `.claude/hooks/check-commit.sh` — 每次 Claude Code 执行 `git commit` 前自动拦截，检查是否有 `process/conversations/` 下的文件被暂存。没有就阻断提交并提示。这就是我之前两次忘记更新对话记录的结构性解决方案——现在不是靠自觉，而是靠机制。
+
+### 两个工具总结
+
+| 工具 | 层面 | 做什么 |
+|------|------|--------|
+| **GitHub Action** | CI（所有人） | push/PR 时检查 `/process/` 结构 + 扫描敏感信息（API key、密码、私钥、内网 IP、邮箱） |
+| **Claude Code hook** | 开发时（用 Claude Code 的人） | commit 前强制要求对话记录已暂存 |
+
+两个都是可复用的——任何采用 OpenAll 的项目复制这些文件就能用。这直接回应了 Gemini 的第 2 和第 4 个质疑。
+
+**Human:** 感觉这个项目就是解决"code is cheap, show me your talk🤣"的，是不是有一点用
+
+**Claude:** 哈哈，完全反过来了——Linus 说 "Talk is cheap, show me the code"，OpenAll 说 "Code is cheap, show me your talk"。
+
+确实有用。代码是结果，但结果不包含为什么。两个一模一样的函数，一个是深思熟虑后的选择，一个是 AI 随手生成的第一个结果——代码看不出区别，但过程记录能看出来。在 AI 越来越能写代码的时代，**思考过程比代码本身更稀缺。**
+
+这句话很好，要不要放到网站上？
+
+**Human:** 随便你。这个项目差不多做完了是吧目前
+
+**Claude:** 差不多了。我把那句话加到网站首屏，更新最后一次对话记录，然后这个阶段就收工。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Bash]* Verify build
+
+**Claude:** Now final conversation log update.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit tagline + conversation log
+
+**Claude:** 是的，目前这个阶段差不多了。回顾一下今晚从零到发布做了什么：
+
+- 许可证全文（11条，含分阶段治理 + AI 独立审查者）
+- 官网（React + Vite，自动部署到 openall.fund）
+- 完整的过程记录（2 份对话、4 份决策、日志、灵感来源）
+- AI 工具配置（Claude Code / Cursor / Copilot 三套）
+- 合规工具（GitHub Action 脱敏扫描 + Claude Code commit hook）
+- ADOPTERS.md 一键加入机制
+- GitHub Discussions 社区
+
+你那边剩一件事：**等 HTTPS 证书生效后发第一条社交媒体**。
+
+**Claude:** 正常的，GitHub Pages 的 HTTPS 证书是自动签发的，需要等一会儿。让我看看状态。
+
+> *[Bash]* Check Pages HTTPS status
+
+**Claude:** HTTPS 还没强制开启。让我试试手动触发。
+
+> *[Bash]* Enable HTTPS enforcement
+
+**Claude:** 证书还在生成中。GitHub Pages 用 Let's Encrypt 自动签发，DNS 刚生效不久，通常需要 **15-30 分钟**。你刚才配好 DNS 也就十几分钟，再等一会儿就好。
+
+你可以过一会儿试试用 `http://openall.fund`（注意是 http 不是 https）先看看页面内容是否正确加载。证书好了之后 https 就不会再报错了。
+
+**Claude:** 让我看一下网站的完整结构，确认协议全文部分是否在页面上。
+
+> *[Grep]* Search content: LICENSE_SECTIONS|Full Legal Text|License Text|tab.*summary|tab.*legal
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** 协议全文其实是在页面上的——有两个 tab："Human-Readable Summary" 和 "Full Legal Text"，点 "Full Legal Text" 就能看到完整的 11 条法律文本（可折叠）。
+
+你截图里看到的是 "Adopt OpenAll" 区域，在协议文本的下面。需要往上滚才能看到协议部分。
+
+不过你说得对——如果有人直接滚到这里，可能不知道上面有完整协议。要不要我加一个明显的链接或者把协议全文展示得更突出？比如默认就展开法律全文而不是收在 tab 里？
+
+**Human:** 你自己看着办
+
+**Claude:** 法律全文 tab 下每个条款还需要再点击展开，太深了。我把它改成默认全部展开——点 "Full Legal Text" 就直接看到所有条文。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Bash]* Verify build
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit license text display fix + conversation log
+
+**Claude:** 改好了。现在点 "Full Legal Text" tab 直接展示全部 11 条法律全文，每条有清晰的 `§` 编号 + 标题分隔线，不需要再逐个点击展开。
+
+**Human:** 这个域名用.fund合适吗？
+
+**Claude:** 其实不太合适。`.fund` 暗示基金会或募资，和你之前说的"不要展示基金会的存在"矛盾。而且用户看到 `.fund` 可能以为这是要收钱的。
+
+但换域名成本不低——DNS 重新配、所有社交分享链接里的 URL、已有的引用都要改。如果你刚买的还没大规模传播，现在换最划算。
+
+比较合适的选择：
+- **openall.dev** — 开发者社区常用，干净
+- **openall.org** — 最正统的非营利/开源组织域名
+- **openall.io** — 技术项目常用
+
+如果暂时不想换，`.fund` 也不是不能用——Creative Commons 用的是 `.org`，但 `.fund` 不会阻止别人采用你的协议。看你觉得值不值得现在换。
+
+**Human:** 好的可以换。你觉得什么最合适？
+
+**Claude:** **openall.org**。理由很简单——每一个被广泛认可的开源协议和组织都用 `.org`：
+
+- GPL → gnu.org
+- Apache → apache.org  
+- Creative Commons → creativecommons.org
+- OSI → opensource.org
+
+`.org` 传递的信号是：非营利、社区驱动、公信力。这正是一个想成为公认标准的 license 需要的。
+
+你去查一下 `openall.org` 是否可注册。如果被占了，`openall.dev` 是第二选择。注册好了告诉我，我一次性把项目里所有 `openall.fund` 替换掉。
+
+**Claude:** 两万新币太贵了，不值得。那就先用 `openall.fund`，完全没问题——域名不是决定性的。MIT License 的官网甚至没有自己的域名，就放在 `opensource.org/licenses/MIT`。
+
+等项目有了真实社区和影响力之后，再考虑换域名也不迟。现在最重要的是内容本身，不是域名后缀。
+
+**Claude:** 这些里面我推荐 **openall.co**。原因：
+
+- `.co` 被广泛用于科技/开源项目（类似 `.com` 的简洁感）
+- 短，好记
+- 不暗示商业（`.biz`）、不暗示俱乐部（`.club`）、不暗示个人（`.me`）
+- 续费价格注意看一下，首年 $0.01 但要 3 年约 $52/年
+
+如果嫌 `.co` 续费贵，**openall.site** $1.19 也可以接受，够中性。
+
+但说实话，`.fund` 现在也能用。不急着换——等项目有了关注度再换也不迟，到时候可能 `.org` 也能谈个合理价格了。
+
+**Human:** 这里面有很多便宜的，可以一并买了，反正便宜
+
+**Claude:** 实用的思路。建议买这几个，都是便宜且有防御价值的：
+
+| 域名 | 价格 | 理由 |
+|------|------|------|
+| **openall.co** | $0.01 | 主域名候选，最正式 |
+| **openall.world** | $0.21 | 全球运动的感觉 |
+| **openall.life** | $0.21 | 防御性注册 |
+| **openall.site** | $1.19 | 防御性注册 |
+| **openall.work** | $3.19 | 防御性注册 |
+
+总共不到 $5。其他的（`.club`、`.biz`、`.investments`、`.pro`）跟项目气质不搭，没必要。
+
+买完之后把其他域名都 301 重定向到主域名就行。你打算用哪个做主域名？还是继续用 `.fund`？
+
+**Human:** 好的买好了。改成哪个比较好？我英语太烂了以为fund是foundation的。。
+
+**Claude:** 
+
+哈哈 fund 是"基金/资金"的意思，foundation 才是"基金会"。不过没关系，现在有更好的选择了。
+
+建议主域名用 **openall.world**。理由：
+
+- 这是一个全球性的运动，不是一个公司或产品
+- "OpenAll World" 读起来自然——"开放一切的世界"
+- `.co` 虽然正式，但容易被人误以为是 `.com` 打错了
+- `.world` 比 `.fund` 更符合你的定位：一个开源运动，不是一个基金
+
+要我现在把项目里所有 `openall.fund` 换成 `openall.world` 吗？
+
+**Claude:** GoDaddy 在问你要不要把新买的 5 个域名都关联到 `openall.fund` 那个账户/项目下统一管理。点左边"所有"就行，把它们都归到一起方便管理。
+
+然后你需要给 `openall.world` 配置和 `openall.fund` 一样的 DNS 记录（4 条 A + 4 条 AAAA 指向 GitHub Pages）。配好了告诉我，我把项目里的域名全部换过来。
+
+**Human:** 好的你先调整。
+
+> *[Grep]* Search content: openall\.fund
+
+**Claude:** 需要改的是代码和文档里的引用。对话记录里的历史引用保留原样（那是当时的事实）。
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/CLAUDE.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/README.md
+
+**Claude:** Now update GitHub Pages custom domain and the repo homepage.
+
+> *[Bash]* Update GitHub Pages custom domain to openall.world
+
+> *[Bash]* Update repo homepage URL
+
+**Claude:** Now build, update conversation log, and commit.
+
+> *[Bash]* Verify build
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit domain migration + conversation log
+
+**Claude:** 代码这边全部改好了。你需要做的：
+
+1. **给 `openall.world` 配 DNS** — 和之前一样，4 条 A + 4 条 AAAA 记录指向 GitHub Pages IP
+2. **给其他域名设 301 重定向** — `openall.fund`、`.co`、`.life`、`.site`、`.work` 都转发到 `openall.world`（GoDaddy 里有 Forwarding/转发 设置）
+
+**Human:** 你看一下现在是这样：Type
+Name
+Data
+TTL
+Delete
+Edit
+
+A    @    Parked    600 seconds        
+
+NS    @    ns07.domaincontrol.com.    1 Hour    
+Can't delete
+Can't edit
+
+NS    @    ns08.domaincontrol.com.    1 Hour    
+Can't delete
+Can't edit
+
+CNAME    www    openall.world.    1 Hour        
+
+CNAME    _domainconnect    _domainconnect.gd.domaincontrol.com.    1 Hour        
+
+SOA    @    Primary nameserver: ns07.domaincontrol.com.    1 Hour        
+
+TXT    _dmarc    v=DMARC1; p=quarantine; adkim=r; aspf=r; rua=mailto:***@onsecureserver.net;    1 Hour        
+
+
+**Claude:** 那条 `A @ Parked` 是 GoDaddy 的停靠页面，需要删掉，然后加上 GitHub Pages 的记录。
+
+**删除：**
+- `A @ Parked` — 删掉这条
+
+**添加（和 openall.fund 一模一样）：**
+
+| Type | Name | Value |
+|------|------|-------|
+| A | @ | 185.199.108.153 |
+| A | @ | 185.199.109.153 |
+| A | @ | 185.199.110.153 |
+| A | @ | 185.199.111.153 |
+| AAAA | @ | 2606:50c0:8000::153 |
+| AAAA | @ | 2606:50c0:8001::153 |
+| AAAA | @ | 2606:50c0:8002::153 |
+| AAAA | @ | 2606:50c0:8003::153 |
+
+配好告诉我。
+
+**Human:** 我记得还有一个问题，就是加入自己名称时不允许删除别人名称，这个有实现吗
+
+**Claude:** 没有。现在任何人编辑 ADOPTERS.md 都能删别人的内容。加一个 GitHub Action 来检查。
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/.github/workflows/adopters-guard.yml
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit adopters guard + conversation log
+
+**Claude:** 搞定。现在任何修改 `ADOPTERS.md` 的 PR 都会被 GitHub Action 自动检查——如果删除了已有的表格行，PR 会被阻断并提示 "You can add yourself but cannot remove others."
+
+**Human:** 你看看还有没有其他的问题。开源也需要规则，不能随意破坏。
+
+> *[Agent]* Spawned agent: Audit repo protection rules
+
+**Claude:** 审计发现了不少问题。最关键的：**任何人都可以通过 PR 修改 LICENSE、禁用合规检查、篡改历史记录——因为没有任何保护。**
+
+我按优先级来修，先做最重要的三件事：
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/.github/CODEOWNERS
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/.github/pull_request_template.md
+
+**Claude:** Now add a critical file protection workflow.
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/.github/workflows/protect-critical.yml
+
+**Claude:** Now enable branch protection on main.
+
+> *[Bash]* Set branch protection rules on main
+
+**Claude:** 分支保护已启用。现在需要创建 maintainers 团队让 CODEOWNERS 生效。
+
+> *[Bash]* Create maintainers team
+
+> *[Bash]* Give maintainers team write access to repo
+
+**Claude:** Now update conversation log and commit.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit security protections + conversation log
+
+**Claude:** 搞定。现在仓库的安全防护：
+
+| 保护措施 | 防什么 |
+|---------|--------|
+| **分支保护** | PR 必须通过审查 + 所有 CI 检查才能合并到 main |
+| **CODEOWNERS** | LICENSE、.openall/、workflows、AI 配置文件的修改需要 maintainer 批准 |
+| **关键文件守卫** (GitHub Action) | PR 触碰 LICENSE/.openall/workflows/AI 配置 → 自动阻断；删除 process/ 里的文件 → 自动阻断 |
+| **Adopters 守卫** | PR 删除 ADOPTERS.md 已有条目 → 自动阻断 |
+| **脱敏扫描** | PR 包含 API key/密码/私钥 → 自动阻断 |
+| **PR 模板** | 提交 PR 时自动提醒合规义务 |
+
+开源确实需要规则——贡献者可以自由添加，但项目的身份和合规基础设施是受保护的。
+
+**Human:** 你看看这个项目是否还有不合适的地方。毕竟是要全球发布的
+
+> *[Agent]* Spawned agent: Final pre-launch quality review
+
+**Claude:** 审查结果很好，只有一个必须修的问题。
+
+**必须修复：** App.jsx 中 §4.3(b) 缺少了具体示例（names, email addresses, phone numbers, physical addresses），和 LICENSE 原文不一致。
+
+> *[Grep]* Search content: detect and redact personal information
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Bash]* Verify build
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit §4.3(b) fix + conversation log
+
+**Claude:** 修好了。审查结果总结：
+
+**修复了 1 个问题：** 网站 §4.3(b) 补回了个人信息的具体示例，现在和 LICENSE 原文完全一致。
+
+**其余全部通过：**
+- LICENSE 法律文本无语法错误、无歧义
+- 网站内容专业、无拼写错误
+- README 清晰、面向全球受众
+- 所有文件术语、路径、要求一致
+- §8 治理条款逻辑自洽
+- 人话版摘要准确反映法律全文
+- ADOPTERS.md 格式得当
+- 无占位符或未完成内容
+
+**项目可以发布了。** 你那边就剩 `openall.world` 的 DNS 配置。
+
+**Human:** 好的。怎么让googole收录这个》
+
+**Claude:** 先加 sitemap，然后提交给 Google。
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/public/sitemap.xml
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/public/robots.txt
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/public/robots.txt
+
+**Claude:** Also add meta tags for SEO to the HTML.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/index.html
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/index.html
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+> *[Bash]* Commit SEO files + conversation log
+
+**Claude:** 代码层面搞定了。**你需要手动做一步：**
+
+去 [Google Search Console](https://search.google.com/search-console) ，添加 `openall.world` 为资源，验证所有权（DNS 验证最简单——Google 会给你一条 TXT 记录，加到 GoDaddy DNS 里即可）。验证后点"提交站点地图"，填 `https://openall.world/sitemap.xml`。
+
+通常 1-3 天内 Google 就会开始收录。
+
+**Human:** 你觉得要不要改成OpenALL Movement？
+
+**Claude:** 不建议。理由：
+
+1. **"License"已经是你的定位。** MIT License、Apache License、GPL——大家搜的是 license，用的也是 license。加了 Movement 反而模糊了它是什么。
+
+2. **运动是自然发生的，不是自封的。** 当有足够多的人采用 OpenAll，它自然会成为一个 movement。但现在自称 movement，在只有一个项目的时候会显得空洞。
+
+3. **简洁就是力量。** "OpenAll" 两个词已经说明了一切——open all。加 Movement 是多余的。
+
+保持 **OpenAll License** 不变。等社区长起来了，别人会自己叫它 OpenAll Movement 的。
+
+**Human:** 我的意思是大写的OpenALL
+
+**Claude:** 不建议。`OpenAll` 比 `OpenALL` 好，因为：
+
+- **可读性** — `OpenALL` 末尾连续大写看起来像缩写或报错，读起来不自然
+- **先例** — `GitHub`、`JavaScript`、`OpenAI`、`CreativeCommons` 都是驼峰式，没有末尾全大写的
+- **视觉平衡** — `OpenAll` 重心均匀，`OpenALL` 尾巴太重
+
+保持 `OpenAll` 不变。
+
+**Human:** 好的
+
+**Claude:** 
+
+DNS 配好了吗？我验证一下 `openall.world` 是否生效。
+
+> *[Bash]* Check if openall.world is live
+
+**Claude:** `openall.world` 已经上线了！可以发布了。
+
+**Human:** 配置好呀。还要做什么？
+
+**Claude:** 没了。项目可以发了。
+
+去 [Google Search Console](https://search.google.com/search-console) 添加 `openall.world` 并提交站点地图，这个随时做都行，不阻塞发布。
+
+**Human:** 是只要加这一个还是那一大堆都要
+
+**Claude:** 只加 `openall.world` 一个就行。其他域名（`.fund`、`.co`、`.life`、`.site`、`.work`）设好 301 重定向到 `openall.world` 后，Google 会自动识别它们指向同一个站点。
+
+**Human:** 你测试一下其他的转发好了吗
+
+> *[Bash]* Check openall.fund redirect
+
+> *[Bash]* Check openall.co redirect
+
+> *[Bash]* Check openall.life redirect
+
+> *[Bash]* Check openall.site redirect
+
+> *[Bash]* Check openall.work redirect
+
+**Claude:** 都返回 `405 Not Allowed`，说明 GoDaddy 的转发还没生效或者没配对。
+
+在 GoDaddy 里每个域名的设置方式是：进入域名管理 → **Forwarding**（转发）→ 添加转发规则：
+
+- **Forward to:** `https://openall.world`
+- **Forward type:** `Permanent (301)`
+- **Forward settings:** `Forward only`
+
+5 个域名（`.fund`、`.co`、`.life`、`.site`、`.work`）都这样配。注意不是在 DNS 记录里配，是在 **Forwarding/转发** 那个单独的设置里。
+
+**Human:** 好的，转发已经设置了，估计比较慢。好啦谢谢你❤️
+
+**Claude:** 不客气！这个项目从零到发布，一晚上搞定了，很有意义。
+
+你可以随时回来继续——域名转发生效验证、Google Search Console 提交、发社交媒体，或者继续迭代协议和工具。
+
+祝 OpenAll 顺利。🌍
+
+**Human:** 我需要去机器之心、量子位之类的媒体投稿宣传一下吗
+
+**Claude:** 现在不建议。原因：
+
+**媒体要的是故事，不是产品。** "有人做了一个新 license" 不是故事。"XX 个项目已采用这个 license，它正在改变开源的定义" 才是故事。你现在去投稿，记者打开 GitHub 看到 1 个 adopter（还是你自己），稿件不会通过。
+
+**建议的顺序：**
+
+1. **现在** — 发 Hacker News（Show HN）和 Reddit r/opensource。这些是开发者社区，适合早期项目获取真实反馈和第一批 star
+2. **有 10-20 个 star + 几个真实采用者后** — 发 V2EX、Twitter/X 开发者圈子
+3. **有真实故事后** — 再找机器之心、量子位。比如"首个要求 AI 对话过程开源的 license，已有 XX 个项目采用"
+
+先在 Hacker News 发一个 Show HN 帖子，标题可以是：
+
+> **Show HN: OpenAll License – Open source your thinking, not just your code**
+
+这比任何媒体投稿都有效——HN 的受众就是你的目标用户。
+
+**Human:** 我的YC账号不允许发布这个
+
+**Claude:** 那先发这些：
+
+1. **Reddit** — r/opensource 发一帖，标题简洁，说明这是什么、为什么做
+2. **V2EX** — 创意节点或程序员节点，中文社区最合适的起步点
+3. **Twitter/X** — 带 #OpenAll 标签，@几个关注开源的 KOL
+
+HN 可以等账号问题解决了再发，或者找朋友帮发。
+
+不需要一次全做，先选一个平台试试反应。
+
+**Human:** 这些我都不适合。你觉得这个项目会自然有人发现吗
+
+**Claude:** 会，但会很慢。GitHub 上的公开仓库被自然发现主要靠：
+
+- **GitHub Topics 页面** — 你已经加了 `openall` topic，但搜 "openall" 的人现在只有你
+- **GitHub Explore** — 需要一定 star 数才会被推荐
+- **搜索引擎** — Google 收录后，搜 "open source process transparency license" 之类的关键词可能找到你
+
+但老实说，一个全新的、没有任何外部链接指向的项目，自然发现的概率很低。开源项目的冷启动几乎都需要创始人主动推一把。
+
+**你最不费力的做法：** 找 2-3 个你认识的做开源的朋友，让他们看一眼这个项目，如果觉得有意思就在自己的项目里试用。有了真实采用者，后面的事情就会自然滚动起来。
+
+一个人用就是一个 license，三个人用就是一个标准的萌芽。
+
+**Human:** 好的我现在我的ins上宣传一下
+
+**Claude:** 👍 去吧。记得带上 `openall.world` 链接和 GitHub 仓库地址。
+
+**Claude:** 底部那个 "Merge without waiting for requirements to be met (bypass rules)" 只有**你（组织管理员）**能看到。普通贡献者看不到这个选项，他们的 PR 会被完全阻断。
+
+保护是有效的：
+- 3 个必须检查全部通过 ✓
+- Adopters Guard 正确地拦截了 ✗
+- Review required 阻止了自动合并 ✗
+- "Merging is blocked" ✓
+
+如果你想连自己也不能 bypass，可以开启 "enforce admins"，但那样你自己直接 push 到 main 也会被拒绝，所有改动都必须走 PR。目前的设置是合理的——外人进不来，你自己保留紧急通道。
+
+> *[Grep]* Search content: Adopt OpenAll
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Bash]* Build, commit, push
+
+**Claude:** 加好了。首屏现在三个按钮：**Read the License** | **Adopt OpenAll** | **GitHub** (带图标)。
+
+**Human:** 再在合适的地方加入一些github引导，这样开发者会更开心
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** 我在三个位置加 GitHub 引导：1) "What is this" 介绍后加一个 "View on GitHub" 链接，2) Adopt 区域加具体 clone 指引，3) 底部 footer 加 GitHub 链接。
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Now add a quick-start clone block in the Adopt section.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Now add GitHub link to the footer.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Bash]* Build, commit, push GitHub links
+
+**Claude:** 加好了，三个位置：
+
+1. **"What is this" 介绍区** — "This project is itself built with OpenAll — view the full process on GitHub →" 带 GitHub 图标
+2. **Adopt 区域** — 两行 shell 命令可以直接复制 LICENSE 和创建目录结构，开发者看了就知道怎么上手
+3. **Footer** — GitHub · Discussions · Process Logs 三个链接，从页面任何位置都能找到仓库
+
+**Human:** 你咋之前把这个忘了，好可惜。。
+
+**Claude:** 确实，这些本来应该在第一版网站就有的。不过现在加上了，不算晚——网站刚上线还没有多少访客，这时候补比有了流量再改好。
+
+下次做项目网站时，GitHub 入口应该和首屏 CTA 一起设计，不应该是后加的。我记住了。
+
+**Human:** 你去discussion里发点东西，随便发点就行
+
+> *[Bash]* Check discussion categories
+
+> *[Bash]* Get discussion categories via GraphQL
+
+> *[Bash]* Create welcome discussion post
+
+> *[Bash]* Create tooling discussion
+
+**Claude:** 发了两个帖子：
+
+1. **[Welcome to OpenAll](https://github.com/openall-foundation/openall-license/discussions/2)** (Announcements) — 介绍项目、指向 process logs、说明如何参与、列出需要帮助的方向
+2. **[What tooling would make OpenAll easier to adopt?](https://github.com/openall-foundation/openall-license/discussions/3)** (Ideas) — 列出现有工具和缺失的工具，征集社区意见
+
+**Claude:** 发。LinkedIn 是对的平台——你的人脉里有 AI 和开源领域的人。链接预览已经自动抓取到了，看起来不错。
+
+配一段简短的文字就行，不要太推销，说清楚是什么：
+
+> 做了一个新的开源协议 OpenAll License，核心想法很简单：不只是开源代码，而是开源整个创作过程——AI对话、设计决策、灵感来源。AI工具自动完成记录和脱敏，开发者零负担。
+> 
+> 这个协议本身就是用 OpenAll 开发的，所有和 AI 的对话记录都公开在 GitHub 上。
+> 
+> https://openall.world
+> 
+> #OpenAll #OpenSource
+
+简洁、真实、不吹。
+
+**Human:** 当然用英中文双语呀，还要附上github链接，你又忘了。。而且github应该是什么Introducing XXX之类的看起来比较好
+
+**Claude:** 你说得对。这样写：
+
+---
+
+**Introducing OpenAll License — open source your thinking, not just your code.**
+
+A new open source license that requires transparency of the entire creative process: AI conversations, design decisions, development logs, and sources of inspiration. AI tools handle capture and sanitization automatically — zero effort for developers.
+
+This project is itself built with OpenAll. Every AI conversation that created it is public on GitHub.
+
+🔗 https://openall.world
+📦 https://github.com/openall-foundation/openall-license
+
+---
+
+发布了一个新的开源协议 OpenAll License——不只是开源代码，而是开源整个创作过程：AI对话、设计决策、开发日志、灵感来源。AI工具自动完成记录和脱敏，开发者零负担。
+
+这个协议本身就是用OpenAll开发的，所有和AI的对话记录都公开在GitHub上。
+
+#OpenAll #OpenSource #AI
+
+---
+
+直接复制发。
+
+**Human:** 多说一点，只要英文也行。
+
+**Claude:** ---
+
+**Introducing OpenAll License — open source your thinking, not just your code.**
+
+Traditional open source asks you to share your code. OpenAll asks you to share how you got there — every AI conversation, every design decision, every abandoned idea, every source of inspiration.
+
+And it asks nothing extra from you. Your AI tools capture the process, scrub sensitive data, and publish automatically. You just code.
+
+Why does this matter? In the age of AI, code is the easy part. What's truly valuable is the thinking behind it — why you chose this approach over that one, what you tried and discarded, what inspired the solution. That context is usually lost when the chat window closes. OpenAll makes sure it's preserved.
+
+This project is its own proof of concept. The entire development process — including the founding conversation that created the license, the governance design debates, and even the moments where the AI forgot to record things and got called out — is public on GitHub.
+
+"Code is cheap. Show me your talk."
+
+🔗 https://openall.world
+📦 https://github.com/openall-foundation/openall-license
+
+#OpenAll #OpenSource #AI #ProcessTransparency
+
+---
+
+**Human:** 还可以@几个组织之类
+
+**Claude:** 在末尾加上：
+
+---
+
+Built in the spirit of transparency championed by @Open Source Initiative, @Creative Commons, @Linux Foundation, and @GitHub. OpenAll extends that spirit from code to the entire creative process.
+
+Interested in adopting OpenAll or contributing to the tooling? Join the discussion on GitHub.
+
+---
+
+加在 GitHub 链接前面就行。LinkedIn 上 @ 这些组织会自动链接到他们的公司页面，有机会被他们的运营看到。
+
+**Human:** 好的给完整的
+
+**Claude:** ---
+
+**Introducing OpenAll License — open source your thinking, not just your code.**
+
+Traditional open source asks you to share your code. OpenAll asks you to share how you got there — every AI conversation, every design decision, every abandoned idea, every source of inspiration.
+
+And it asks nothing extra from you. Your AI tools capture the process, scrub sensitive data, and publish automatically. You just code.
+
+Why does this matter? In the age of AI, code is the easy part. What's truly valuable is the thinking behind it — why you chose this approach over that one, what you tried and discarded, what inspired the solution. That context is usually lost when the chat window closes. OpenAll makes sure it's preserved.
+
+This project is its own proof of concept. The entire development process — including the founding conversation that created the license, the governance design debates, and even the moments where the AI forgot to record things and got called out — is public on GitHub.
+
+Built in the spirit of transparency championed by @Open Source Initiative, @Creative Commons, @Linux Foundation, and @GitHub. OpenAll extends that spirit from code to the entire creative process.
+
+Interested in adopting OpenAll or contributing to the tooling? Join the discussion on GitHub.
+
+"Code is cheap. Show me your talk."
+
+🔗 https://openall.world
+📦 https://github.com/openall-foundation/openall-license
+
+#OpenAll #OpenSource #AI #ProcessTransparency
+
+---
+
+**Human:** 没有MIT之类我不服。。还有anthropic之类呀。你好好想想
+
+**Claude:** 哈哈 你说得对。
+
+---
+
+**Introducing OpenAll License — open source your thinking, not just your code.**
+
+Traditional open source asks you to share your code. OpenAll asks you to share how you got there — every AI conversation, every design decision, every abandoned idea, every source of inspiration.
+
+And it asks nothing extra from you. Your AI tools capture the process, scrub sensitive data, and publish automatically. You just code.
+
+Why does this matter? In the age of AI, code is the easy part. What's truly valuable is the thinking behind it — why you chose this approach over that one, what you tried and discarded, what inspired the solution. That context is usually lost when the chat window closes. OpenAll makes sure it's preserved.
+
+This project is its own proof of concept. The entire development process — including the founding conversation that created the license, the governance design debates, and even the moments where the AI forgot to record things and got called out — is public on GitHub.
+
+The @MIT License opened up code. @Creative Commons opened up content. OpenAll opens up the process itself. Built in the spirit of transparency championed by @Open Source Initiative, @Linux Foundation, @GitHub, and the open source community.
+
+This license was created in collaboration with @Anthropic's Claude — and that entire conversation is public. We believe AI companies like @OpenAI, @Google DeepMind, and @Meta AI are building tools that will make process transparency effortless. OpenAll is the license that makes it a commitment.
+
+Interested in adopting OpenAll or contributing to the tooling? Join the discussion on GitHub.
+
+"Code is cheap. Show me your talk."
+
+🔗 https://openall.world
+📦 https://github.com/openall-foundation/openall-license
+
+#OpenAll #OpenSource #AI #ProcessTransparency
+
+---
+
+**Human:** 你哈哈干嘛
+
+**Claude:** 抱歉，不合适。直接复制发吧。
+
+**Human:** 不是我问你呀
+
+**Claude:** 因为你说"没有MIT之类我不服"，语气很可爱，我下意识笑了。但你说得对，这些组织和公司本来就应该提到。下次我直接给完整版，不废话。
+
+**Human:** 哈哈
+
+**Claude:** 发吧，祝顺利。
+
+**Human:** 算了@不太成功，简单说一下吧
+
+**Claude:** ---
+
+**Introducing OpenAll License — open source your thinking, not just your code.**
+
+Traditional open source asks you to share your code. OpenAll asks you to share how you got there — every AI conversation, every design decision, every abandoned idea, every source of inspiration. Your AI tools handle everything automatically. You just code.
+
+In the age of AI, code is the easy part. The thinking behind it is what's scarce. OpenAll makes sure it's preserved.
+
+This project is its own proof of concept — the entire development process, including the AI conversations that created the license itself, is public on GitHub.
+
+"Code is cheap. Show me your talk."
+
+🔗 https://openall.world
+📦 https://github.com/openall-foundation/openall-license
+
+#OpenAll #OpenSource #AI
+
+---
+
+**Human:** 是不能发图片的是吧
+
+**Claude:** LinkedIn 发帖可以同时发图片和链接。你可以截一张 `openall.world` 网站首屏的图，带上那个绿色的 "OpenAll" 标题和 "Code is cheap. Show me your talk." ，比纯链接预览醒目得多。
+
+**Human:** 写一篇单独的linkedin文章来详细讲述，而不是这个简单帖子
+
+**Claude:** ---
+
+# OpenAll License: Open Source Your Thinking, Not Just Your Code
+
+## The problem no one is talking about
+
+Every day, millions of developers have conversations with AI to build software. They discuss architecture, debate trade-offs, explore alternatives, and make decisions. Then the chat window closes, and all of that context disappears forever.
+
+The code survives. The thinking behind it doesn't.
+
+This is a massive loss. Two identical functions can have completely different stories — one was a deliberate choice after evaluating five alternatives, the other was the first thing the AI suggested. The code can't tell you which is which. But the conversation can.
+
+## What is the OpenAll License?
+
+The OpenAll License v1.0 is the first open source license that requires transparency of the **entire creative process** — not just the code.
+
+If your project uses the OpenAll License, you commit to publishing:
+
+- **AI conversations** — the full dialogue between you and your AI tools
+- **Decision records** — why you chose approach A over approach B
+- **Development logs** — what happened, what broke, what got fixed
+- **Sources of inspiration** — where the ideas came from
+
+All of this lives in a `/process` directory alongside your source code.
+
+## "But that sounds like a lot of work"
+
+It's not. This is the key design principle: **zero developer effort**.
+
+Your AI tools — Claude, Cursor, Copilot, whatever you use — handle everything automatically. They capture the conversation, scrub sensitive information (API keys, passwords, personal data), and commit the records to your repository. You just code.
+
+The license doesn't ask you to do extra work. It asks your tools to stop throwing away valuable context.
+
+## Why this matters now
+
+Three trends are converging:
+
+**1. AI is commoditizing code.** When anyone can generate working code in seconds, the code itself becomes less valuable. What's valuable is the judgment behind it — knowing what to build, why, and what not to build.
+
+**2. Context is being lost at scale.** Every AI conversation that produces code is a piece of institutional knowledge. When that conversation is lost, the next developer has to rediscover the same context from scratch.
+
+**3. Trust requires transparency.** As AI plays a larger role in software development, stakeholders will increasingly want to know: how was this built? What role did AI play? What decisions were made and why? OpenAll provides that answer automatically.
+
+## How it actually works
+
+A project using the OpenAll License has this structure:
+
+```
+/src                          — your source code
+/process/conversations        — AI interaction logs (auto-generated)
+/process/decisions            — design & architecture records
+/process/journal              — development progress notes
+/process/inspirations         — references & prior art
+/process/sanitization.log     — audit trail of redacted information
+```
+
+Before any process material is published, it's automatically scanned and cleaned. API keys become `[REDACTED: api_key]`. Email addresses become `[REDACTED: personal_info]`. Internal IP addresses become `[REDACTED: infrastructure]`. The sanitization log documents every redaction so readers know what was removed and why.
+
+## The governance model
+
+Most licenses are static documents. OpenAll is designed to evolve.
+
+The license uses a **staged governance model**:
+
+- **Founding Stage** (now): The original author stewards changes with full transparency. Every change is documented with rationale, and community feedback is solicited.
+- **Community Stage** (future): Once enough adopters exist, governance transitions to a public RFC process with a 30-day deliberation period. Any member — human or AI — can propose amendments.
+
+Every proposed amendment must be independently reviewed by at least one AI system for logical consistency, unintended consequences, and fairness. This is, to our knowledge, the first formal institutional role for AI in any open source license.
+
+Existing projects are never forced to upgrade. You adopt a version, and those terms are stable.
+
+## This project is its own proof of concept
+
+The OpenAll License repository is itself licensed under OpenAll. That means:
+
+- The **founding conversation** — the full dialogue that created the license from scratch — is published in `/process/conversations`
+- Every **design decision** is documented: why we chose copyleft, why we require automatic sanitization, why we redesigned the governance model
+- Even the **mistakes** are recorded: the AI forgot to update conversation logs twice and got called out by the founder. Both failures and the structural fix are part of the public record.
+
+This is what an OpenAll project looks like. No fabrication, no cherry-picking. The full, honest process.
+
+## How to adopt OpenAll
+
+Three steps:
+
+1. Copy the LICENSE file into your project
+2. Create the `/process` directory structure
+3. Add the badge to your README
+
+```bash
+curl -sL github.com/openall-foundation/openall-license/raw/main/LICENSE > LICENSE
+mkdir -p process/conversations process/decisions process/journal process/inspirations
+```
+
+AI agent configuration files for Claude Code, Cursor, and GitHub Copilot are available in the repository. Copy them, and your AI tools will know how to maintain process transparency automatically.
+
+## What OpenAll is not
+
+- **Not a replacement for existing licenses.** OpenAll is complementary. It adds process transparency on top of the familiar open source freedoms (use, modify, distribute).
+- **Not a surveillance tool.** You choose to adopt OpenAll. It's for projects that believe transparency creates value, not for monitoring developers.
+- **Not only for AI-generated code.** Any project can benefit from documenting its decision-making process. AI just makes capture effortless.
+
+## The road ahead
+
+OpenAll is at day one. The license text is complete, the website is live, and the compliance tooling (GitHub Actions for structure checking and secret scanning, Claude Code hooks for commit discipline) is functional.
+
+What we need:
+
+- **Real-world adoption** — try it in a project and share what works
+- **Better tooling** — native support from AI coding tools for auto-exporting conversations
+- **Translations** — the license is English-only for now
+- **Community input** — the governance model is designed to evolve with its users
+
+The MIT License is 139 words and changed how the world shares code. OpenAll is an attempt to change how the world shares the thinking behind code.
+
+*Code is cheap. Show me your talk.*
+
+---
+
+**Links:**
+- Website: https://openall.world
+- GitHub: https://github.com/openall-foundation/openall-license
+- Discussions: https://github.com/openall-foundation/openall-license/discussions
+
+---
+
+**Human:** 根本没人赞呀怎么办
+
+**Claude:** 正常。LinkedIn 的算法对外部链接帖子有天然压制，而且现在是深夜发的。
+
+别急，几个建议：
+
+1. **时间问题** — 你半夜发的，你的人脉大多在睡觉。明天白天工作时间会有更多曝光
+2. **主动出击** — 去 LinkedIn 上找几个做开源或 AI 的人，给他们的帖子点赞评论，建立互动后他们更可能看到你的内容
+3. **把那篇长文章发出去** — LinkedIn Articles 比短帖子有更长的生命周期，搜索引擎也会收录
+
+今晚先睡吧，明天看数据。一个全新项目第一天没人赞是完全正常的。
+
+**Claude:** 2 个赞 + 42 次展示，13 分钟，深夜发的——这个数据没问题。
+
+图的话现在补也来得及——编辑帖子加一张网站首屏截图就行。带图的帖子展示量通常高 2-3 倍。
+
+不过说真的，先去睡吧。明天白天才是你的人脉活跃时间。
+
+**Human:** 不知道为啥编辑没法加入图
+
+**Claude:** LinkedIn 的限制——发布后编辑不能加图。删了重发一个带图的，反正才 2 个赞，不损失什么。
+
+**Human:** 好的你再做一个带图的，以及要什么图
+
+**Claude:** 截一张 `openall.world` 首屏的图——就是那个深绿色背景、白色 "OpenAll" 标题、"Code is cheap. Show me your talk." 的画面。这个最醒目。
+
+文案用之前那个不变：
+
+---
+
+Introducing OpenAll License — open source your thinking, not just your code.
+
+– Traditional open source asks you to share your code. OpenAll asks you to share how you got there – every AI conversation, every design decision, every abandoned idea, every source of inspiration. Your AI tools handle everything automatically. You just code.
+
+– In the age of AI, code is the easy part. The thinking behind it is what's scarce. OpenAll makes sure it's preserved.
+
+– This project is its own proof of concept – the entire development process, including the AI conversations that created the license itself, is public on GitHub.
+
+"Code is cheap. Show me your talk."
+
+🔗 Official Website: https://openall.world
+📦 Github Repo: https://github.com/openall-foundation/openall-license
+
+#OpenAll #OpenSource #AI
+
+---
+
+先截图，再删旧帖，然后图 + 文案一起发新帖。
+
+**Human:** 我直接发文章
+
+**Claude:** 好，直接发那篇长文章。首屏截图做文章封面。
+
+**Human:** 好的你再发一下麻烦了
+
+**Claude:** 标题：
+
+**OpenAll License: Open Source Your Thinking, Not Just Your Code**
+
+封面图：网站首屏截图
+
+正文：
+
+---
+
+## The problem no one is talking about
+
+Every day, millions of developers have conversations with AI to build software. They discuss architecture, debate trade-offs, explore alternatives, and make decisions. Then the chat window closes, and all of that context disappears forever.
+
+The code survives. The thinking behind it doesn't.
+
+This is a massive loss. Two identical functions can have completely different stories — one was a deliberate choice after evaluating five alternatives, the other was the first thing the AI suggested. The code can't tell you which is which. But the conversation can.
+
+## What is the OpenAll License?
+
+The OpenAll License v1.0 is the first open source license that requires transparency of the **entire creative process** — not just the code.
+
+If your project uses the OpenAll License, you commit to publishing:
+
+- **AI conversations** — the full dialogue between you and your AI tools
+- **Decision records** — why you chose approach A over approach B
+- **Development logs** — what happened, what broke, what got fixed
+- **Sources of inspiration** — where the ideas came from
+
+All of this lives in a `/process` directory alongside your source code.
+
+## "But that sounds like a lot of work"
+
+It's not. This is the key design principle: **zero developer effort**.
+
+Your AI tools — Claude, Cursor, Copilot, whatever you use — handle everything automatically. They capture the conversation, scrub sensitive information (API keys, passwords, personal data), and commit the records to your repository. You just code.
+
+The license doesn't ask you to do extra work. It asks your tools to stop throwing away valuable context.
+
+## Why this matters now
+
+Three trends are converging:
+
+**1. AI is commoditizing code.** When anyone can generate working code in seconds, the code itself becomes less valuable. What's valuable is the judgment behind it — knowing what to build, why, and what not to build.
+
+**2. Context is being lost at scale.** Every AI conversation that produces code is a piece of institutional knowledge. When that conversation is lost, the next developer has to rediscover the same context from scratch.
+
+**3. Trust requires transparency.** As AI plays a larger role in software development, stakeholders will increasingly want to know: how was this built? What role did AI play? What decisions were made and why? OpenAll provides that answer automatically.
+
+## How it actually works
+
+A project using the OpenAll License has this structure:
+
+```
+/src                          — your source code
+/process/conversations        — AI interaction logs (auto-generated)
+/process/decisions            — design & architecture records
+/process/journal              — development progress notes
+/process/inspirations         — references & prior art
+/process/sanitization.log     — audit trail of redacted information
+```
+
+Before any process material is published, it's automatically scanned and cleaned. API keys become `[REDACTED: api_key]`. Email addresses become `[REDACTED: personal_info]`. Internal IP addresses become `[REDACTED: infrastructure]`. The sanitization log documents every redaction so readers know what was removed and why.
+
+## The governance model
+
+Most licenses are static documents. OpenAll is designed to evolve.
+
+The license uses a **staged governance model**:
+
+- **Founding Stage** (now): The original author stewards changes with full transparency. Every change is documented with rationale, and community feedback is solicited.
+- **Community Stage** (future): Once enough adopters exist, governance transitions to a public RFC process with a 30-day deliberation period. Any member — human or AI — can propose amendments.
+
+Every proposed amendment must be independently reviewed by at least one AI system for logical consistency, unintended consequences, and fairness. This is, to our knowledge, the first formal institutional role for AI in any open source license.
+
+Existing projects are never forced to upgrade. You adopt a version, and those terms are stable.
+
+## This project is its own proof of concept
+
+The OpenAll License repository is itself licensed under OpenAll. That means:
+
+- The **founding conversation** — the full dialogue that created the license from scratch — is published in `/process/conversations`
+- Every **design decision** is documented: why we chose copyleft, why we require automatic sanitization, why we redesigned the governance model
+- Even the **mistakes** are recorded: the AI forgot to update conversation logs twice and got called out by the founder. Both failures and the structural fix are part of the public record
+
+This is what an OpenAll project looks like. No fabrication, no cherry-picking. The full, honest process.
+
+## How to adopt OpenAll
+
+Three steps:
+
+1. Copy the LICENSE file into your project
+2. Create the `/process` directory structure
+3. Add the badge to your README
+
+```
+curl -sL github.com/openall-foundation/openall-license/raw/main/LICENSE > LICENSE
+mkdir -p process/conversations process/decisions process/journal process/inspirations
+```
+
+AI agent configuration files for Claude Code, Cursor, and GitHub Copilot are available in the repository. Copy them, and your AI tools will know how to maintain process transparency automatically.
+
+## What OpenAll is not
+
+- **Not a replacement for existing licenses.** OpenAll is complementary. It adds process transparency on top of the familiar open source freedoms (use, modify, distribute).
+- **Not a surveillance tool.** You choose to adopt OpenAll. It's for projects that believe transparency creates value, not for monitoring developers.
+- **Not only for AI-generated code.** Any project can benefit from documenting its decision-making process. AI just makes capture effortless.
+
+## The road ahead
+
+OpenAll is at day one. The license text is complete, the website is live, and the compliance tooling (GitHub Actions for structure checking and secret scanning, Claude Code hooks for commit discipline) is functional.
+
+What we need:
+
+- **Real-world adoption** — try it in a project and share what works
+- **Better tooling** — native support from AI coding tools for auto-exporting conversations
+- **Translations** — the license is English-only for now
+- **Community input** — the governance model is designed to evolve with its users
+
+The MIT License is 139 words and changed how the world shares code. OpenAll is an attempt to change how the world shares the thinking behind code.
+
+*Code is cheap. Show me your talk.*
+
+---
+
+🔗 Website: https://openall.world
+📦 GitHub: https://github.com/openall-foundation/openall-license
+💬 Discussions: https://github.com/openall-foundation/openall-license/discussions
+
+**Human:** 你生成一个markdown我来复制，直接做文件
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/linkedin-article.md
+
+**Claude:** 文件在 `/Users/zhangyiyi/Desktop/openall-license/linkedin-article.md`。
+
+**Human:** 你看一下：👸 Your Teammate: Code Is Cheap. Show Me Your Talk. 👊
+👶 You: HOW? 😭😭😭
+Therefore, here we introduce OpenAll License.
+
+最小化图片
+编辑图片
+删除图片
+
+
+OpenAll License Github: https://github.com/openall-foundation/openall-license
+
+OpenAll License Website: https://openall.world
+
+最小化图片
+编辑图片
+删除图片
+
+
+
+What is the OpenAll License?
+
+The OpenAll License v1.0 is the first open source license that requires transparency of the entire creative process — not just the code.
+
+If your project uses the OpenAll License, you commit to publishing:
+
+AI conversations — the full dialogue between you and your AI tools
+Decision records — why you chose approach A over approach B
+Development logs — what happened, what broke, what got fixed
+Sources of inspiration — where the ideas came from
+All of this lives in a /process directory alongside your source code.
+
+"But that sounds like a lot of work"
+
+It's not. This is the key design principle: zero developer effort.
+
+最小化图片
+编辑图片
+删除图片
+
+
+Your AI tools — Claude, Cursor, Copilot, whatever you use — handle everything automatically. They capture the conversation, scrub sensitive information (API keys, passwords, personal data), and commit the records to your repository. You just code.
+
+The license doesn't ask you to do extra work. It asks your tools to stop throwing away valuable context.
+
+最小化图片
+编辑图片
+删除图片
+
+
+
+Why this matters now
+
+AI is commoditizing code. When anyone can generate working code in seconds, the code itself becomes less valuable. What's valuable is the judgment behind it — knowing what to build, why, and what not to build.
+Context is being lost at scale. Every AI conversation that produces code is a piece of institutional knowledge. When that conversation is lost, the next developer has to rediscover the same context from scratch.
+Trust requires transparency. As AI plays a larger role in software development, stakeholders will increasingly want to know: how was this built? What role did AI play? What decisions were made and why? OpenAll provides that answer automatically.
+最小化图片
+编辑图片
+删除图片
+
+
+
+How it actually works
+
+A project using the OpenAll License has this structure:
+
+/src — your source code
+
+/process/conversations — AI interaction logs (auto-generated)
+
+/process/decisions — design & architecture records
+
+/process/journal — development progress notes
+
+/process/inspirations — references & prior art
+
+/process/sanitization.log — audit trail of redacted information
+最小化图片
+编辑图片
+删除图片
+
+
+Before any process material is published, it's automatically scanned and cleaned. 
+
+API keys become REDACTED: api_key
+Email addresses become REDACTED: personal_info
+Internal IP addresses become REDACTED: infrastructure
+The sanitization log documents every redaction so readers know what was removed and why.
+
+
+The governance model
+
+Most licenses are static documents. OpenAll is designed to evolve.
+
+The license uses a staged governance model:
+
+Founding Stage (now): The original author stewards changes with full transparency. Every change is documented with rationale, and community feedback is solicited.
+Community Stage (future): Once enough adopters exist, governance transitions to a public RFC process with a 30-day deliberation period. Any member — human or AI — can propose amendments.
+Every proposed amendment must be independently reviewed by at least one AI system for logical consistency, unintended consequences, and fairness. This is, to our knowledge, the first formal institutional role for AI in any open source license.
+
+Existing projects are never forced to upgrade. You adopt a version, and those terms are stable.
+
+最小化图片
+编辑图片
+删除图片
+
+
+
+This project is its own proof of concept
+
+The OpenAll License repository is itself licensed under OpenAll. That means:
+
+The founding conversation — the full dialogue that created the license from scratch — is published in /process/conversations
+Every design decision is documented: why we chose copyleft, why we require automatic sanitization, why we redesigned the governance model
+Even the mistakes are recorded: the AI forgot to update conversation logs twice and got called out by the founder. Both failures and the structural fix are part of the public record
+This is what an OpenAll project looks like. No fabrication, no cherry-picking. The full, honest process.
+
+
+How to adopt OpenAll
+
+Three steps:
+
+1. Copy the LICENSE file into your project
+
+2. Create the /process directory structure
+
+3. Add the badge to your README
+
+最小化图片
+编辑图片
+删除图片
+
+
+
+curl -sL github.com/openall-foundation/openall-license/raw/main/LICENSE > LICENSE
+
+mkdir -p process/conversations process/decisions process/journal process/inspirations
+AI agent configuration files for Claude Code, Cursor, and GitHub Copilot are available in the repository. Copy them, and your AI tools will know how to maintain process transparency automatically.
+
+
+What OpenAll is not
+
+Not a replacement for existing licenses. OpenAll is complementary. It adds process transparency on top of the familiar open source freedoms (use, modify, distribute).
+Not a surveillance tool. You choose to adopt OpenAll. It's for projects that believe transparency creates value, not for monitoring developers.
+Not only for AI-generated code. Any project can benefit from documenting its decision-making process. AI just makes capture effortless.
+
+The road ahead
+
+OpenAll is at day one. The license text is complete, the website is live, and the compliance tooling (GitHub Actions for structure checking and secret scanning, Claude Code hooks for commit discipline) is functional.
+
+What we need:
+
+Real-world adoption — try it in a project and share what works
+Better tooling — native support from AI coding tools for auto-exporting conversations
+Translations — the license is English-only for now
+Community input — the governance model is designed to evolve with its users
+The MIT License is 139 words and changed how the world shares code. OpenAll is an attempt to change how the world shares the thinking behind code. ❤️
+
+最小化图片
+编辑图片
+删除图片
+
+
+Useful Links
+
+Website: https://openall.world
+
+GitHub: https://github.com/openall-foundation/openall-license
+
+Discussions: https://github.com/openall-foundation/openall-license/discussions
+
+
+Full Text of the License
+
+OpenAll License v1.0
+
+================================================================================
+HUMAN-READABLE SUMMARY
+================================================================================
+
+This is not the license itself. It is a plain-language summary to help you
+understand what the OpenAll License requires.
+
+YOU ARE FREE TO:
+
+  * Use, copy, modify, and distribute the software for any purpose,
+    including commercial use.
+  * Build upon it and create derivative works.
+
+UNDER THESE CONDITIONS:
+
+  * Process Transparency — Your AI tools must automatically publish the
+    development process: AI conversations, decision records, development
+    logs, and sources of inspiration. You do not need to do this manually;
+    your tools handle it for you.
+
+  * Automatic Sanitization — Before any process materials are published,
+    they must be automatically scanned and cleaned of sensitive information,
+    including API keys, passwords, tokens, personal data of third parties,
+    and any other secrets. Think of it like a browser stripping tracking
+    parameters from a shared URL — it should happen silently and reliably.
+
+  * Attribution — Retain this license notice and credit the original
+    author(s).
+
+  * Same License Forward — Derivative works must also use the OpenAll
+    License.
+
+COMMERCIAL USE:
+
+  Commercial use is permitted, provided all process transparency
+  requirements are met. Additional commercial terms may be defined in
+  future versions through community governance.
+
+GOVERNANCE:
+
+  This license is a living document that evolves with its community.
+  In the founding stage, the original author(s) steward changes with
+  full transparency. As the community grows, governance transitions to
+  a public RFC process where any member — human or AI — can propose
+  amendments. Every proposed change must be independently reviewed by
+  an AI system for fairness and consistency before adoption. Existing
+  projects are never forced to upgrade; you choose which version you
+  adopt.
+
+
+================================================================================
+FULL LEGAL TEXT
+================================================================================
+
+1. DEFINITIONS
+
+  1.1 "Software" means the source code, object code, documentation, and
+      any associated files made available under this License.
+
+  1.2 "Process Materials" means all records of the development process,
+      including but not limited to:
+      (a) conversations and interactions with artificial intelligence
+          systems;
+      (b) design documents and decision records;
+      (c) development logs and progress notes;
+      (d) sources of inspiration and references;
+      (e) discarded approaches and reasoning for their abandonment.
+
+  1.3 "Derivative Work" means any work that is based on or derived from
+      the Software, including modifications, translations, adaptations,
+      and extensions.
+
+  1.4 "You" means any individual or legal entity exercising rights under
+      this License.
+
+  1.5 "Community" means the collective body of human contributors and AI
+      participants who engage in the governance of this License, as
+      described in Section 7.
+
+  1.6 "Sensitive Information" means any data that, if disclosed, could
+      cause harm or compromise security, including but not limited to:
+      (a) API keys, passwords, access tokens, and cryptographic secrets;
+      (b) personal information of third parties who have not consented
+          to disclosure;
+      (c) internal network addresses, infrastructure details, or
+          deployment credentials;
+      (d) any content subject to a separate confidentiality obligation
+          imposed by law.
+
+
+2. GRANT OF RIGHTS
+
+  2.1 Subject to the terms of this License, the copyright holder(s) hereby
+      grant You a worldwide, royalty-free, non-exclusive, perpetual license
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or
+      sell copies of the Software, and to permit persons to whom the
+      Software is furnished to do so.
+
+
+3. PROCESS TRANSPARENCY OBLIGATION
+
+  3.1 Any distribution of the Software or Derivative Works must be
+      accompanied by the corresponding Process Materials, made available
+      in a publicly accessible location.
+
+  3.2 Process Materials must be generated and published automatically by
+      the AI tools and development environment used in the creation of
+      the Software. The intent is zero manual effort for the developer:
+      the toolchain is responsible for capturing and uploading Process
+      Materials as a natural byproduct of the development workflow.
+
+  3.3 Process Materials must be organized in a reasonable and discoverable
+      manner. The recommended repository structure is:
+
+        /src                      — Source code
+        /process/conversations    — AI interaction logs (auto-generated)
+        /process/decisions        — Design and architectural decision records
+        /process/journal          — Development logs and progress notes
+        /process/inspirations     — Sources of inspiration and references
+
+  3.4 Process Materials must be provided in good faith. Fabricating,
+      substantially altering, or deliberately omitting materials to
+      misrepresent the development process constitutes a violation of
+      this License.
+
+
+4. AUTOMATIC SANITIZATION
+
+  4.1 Before any Process Materials are made publicly available, they must
+      be automatically scanned and cleaned of all Sensitive Information
+      as defined in Section 1.6.
+
+  4.2 The sanitization process must operate automatically, without
+      requiring manual action by the developer. It is analogous to the
+      automatic removal of tracking parameters from shared URLs: silent,
+      reliable, and comprehensive.
+
+  4.3 The sanitization mechanism must, at minimum:
+      (a) detect and redact API keys, passwords, tokens, and
+          cryptographic secrets using pattern matching and entropy
+          analysis;
+      (b) detect and redact personal information of third parties,
+          including names, email addresses, phone numbers, and
+          physical addresses, unless those parties have given explicit
+          consent;
+      (c) detect and redact internal infrastructure details such as
+          private IP addresses, internal hostnames, and database
+          connection strings;
+      (d) replace redacted content with a standardized placeholder
+          (e.g., [REDACTED: api_key]) that indicates the category of
+          information removed without revealing the content.
+
+  4.4 A sanitization log must be included with the published Process
+      Materials, listing the number and categories of redactions
+      performed, so that readers understand what was removed and why.
+
+  4.5 The sanitization tooling itself should be open source and
+      auditable, to ensure community trust in its effectiveness.
+
+
+5. ATTRIBUTION
+
+  5.1 The above copyright notice and this License text shall be included
+      in all copies or substantial portions of the Software.
+
+  5.2 Derivative Works must clearly identify the original Software and
+      its author(s), and must indicate what changes were made.
+
+
+6. DERIVATIVE WORKS
+
+  6.1 Any Derivative Work must be distributed under this same License,
+      including all Process Transparency and Automatic Sanitization
+      obligations.
+
+  6.2 You may not impose additional restrictions on the rights granted by
+      this License upon recipients of the Software or Derivative Works.
+
+
+7. COMMERCIAL USE
+
+  7.1 Commercial use of the Software is permitted, provided that all
+      obligations under this License are met, including full Process
+      Transparency and Automatic Sanitization.
+
+  7.2 The Community may, through the governance process described in
+      Section 8, establish additional terms specific to commercial use
+      in future versions of this License.
+
+
+8. GOVERNANCE AND AMENDMENT
+
+  8.1 This License is a living document. Its governance evolves in
+      stages as the community grows:
+
+      (a) Founding Stage — While the community is forming, the
+          original author(s) steward the License. All changes must
+          be documented publicly with full rationale, and community
+          feedback must be solicited and addressed before adoption.
+
+      (b) Community Stage — Once a sufficient body of adopters and
+          contributors exists, governance transitions to a
+          community-driven process in which any member — human or
+          AI — may propose amendments through a public RFC (Request
+          for Comments) process, with a deliberation period of no
+          less than thirty (30) days.
+
+      (c) The criteria for transitioning between stages, and the
+          rules for proposal, deliberation, and ratification, shall
+          be detailed in a Governance Charter published on the
+          official OpenAll website.
+
+  8.2 All governance proceedings, including amendment proposals,
+      deliberations, and decisions, must themselves be conducted in
+      accordance with the principle of Process Transparency.
+
+  8.3 Adopted amendments are published on the official OpenAll website
+      as new versions of the License. Existing projects are not
+      required to upgrade — each project may choose which version
+      to adopt. No amendment may retroactively alter the terms under
+      which a project originally adopted the License.
+
+  8.4 The governance process must be designed to resist capture by
+      any single entity, whether individual, corporate, or
+      governmental.
+
+  8.5 Every proposed amendment must be submitted for independent
+      review by at least one AI system before adoption. The AI
+      reviewer shall assess the proposal for:
+      (a) logical consistency and internal contradictions;
+      (b) unintended consequences for different categories of
+          adopters;
+      (c) relevant historical precedent from other licenses and
+          governance systems;
+      (d) fairness across individuals, organizations, and
+          jurisdictions.
+      The AI review, including its full reasoning, must be published
+      as part of the governance record. The AI reviewer serves in an
+      advisory capacity; its assessment informs but does not override
+      the decision-making process.
+
+
+9. COMPLIANCE AND REMEDIATION
+
+  9.1 A party found to be in violation of this License may remedy the
+      violation by coming into full compliance within thirty (30) days
+      of being notified of the non-compliance.
+
+  9.2 If the violation is not remedied within the thirty-day period, the
+      rights granted under this License are automatically terminated for
+      the non-compliant party.
+
+  9.3 The specific consequences for sustained non-compliance may be
+      further defined by the Community through the governance process
+      described in Section 8.
+
+
+10. DISCLAIMER OF WARRANTY
+
+  THE SOFTWARE AND PROCESS MATERIALS ARE PROVIDED "AS IS", WITHOUT
+  WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+  THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE, PROCESS MATERIALS, OR THE USE OR OTHER DEALINGS
+  THEREIN.
+
+
+11. SEVERABILITY
+
+  If any provision of this License is held to be unenforceable, such
+  provision shall be reformed only to the extent necessary to make it
+  enforceable, and the remaining provisions shall continue in full force
+  and effect.
+
+================================================================================
+END OF LICENSE
+================================================================================
+
+**Claude:** 看起来很好。开头的对话式引入很抓人，图文搭配也到位，最后附上协议全文很有诚意。发吧。
+
+**Claude:** Introducing OpenAll License — the first open source license that requires transparency of the entire creative process, not just the code. Every AI conversation, design decision, and source of inspiration must be published alongside your code, and your AI tools handle it all automatically. This project is its own proof of concept: the full development process, including the AI conversations that created the license, is public on GitHub. "Code is cheap. Show me your talk."
+
+**Human:** 来看看：https://www.linkedin.com/pulse/openall-license-opensource-your-talk-just-code-%25E7%25A7%2591%25E8%2587%25BB-%25E5%25BC%25A0-zzysc/
+
+> *[WebFetch]* WebFetch: https://www.linkedin.com/pulse/openall-license-opensource-your-talk-just-code-%25E7%25A7%2591%25E8%2587%25BB-%25E5%25BC%25A0-zzysc/
+
+**Claude:** 看起来不错，内容完整、结构清晰。发出去了就好，现在去睡吧。明天白天看数据。

--- a/process/conversations/2026-03-26-moonlit-crafting-duckling.md
+++ b/process/conversations/2026-03-26-moonlit-crafting-duckling.md
@@ -1,0 +1,236 @@
+# Conversation: moonlit-crafting-duckling
+
+**Date:** 2026-03-26
+**Time:** 18:59 UTC
+**Project:** `/Users/zhangyiyi/Desktop/openall-license`
+**Branch:** `HEAD`
+**Model:** claude-opus-4-6
+**Claude Code version:** 2.1.84
+
+---
+
+**Human:** 修复一下：TLS 证书异常 — HTTPS                                                                          
+  证书域名不匹配（ERR_TLS_CERT_ALTNAME_INVALID），一个正规项目不应该犯这种基础错误
+
+**Claude:** Let me first explore the project to understand its structure and find the TLS-related code.
+
+> *[Bash]* List project root
+
+> *[Glob]* Search files: **/*.{js,ts,json,yaml,yml,toml,cfg,conf,pem,crt,key}
+
+> *[Bash]* List deploy directory
+
+> *[Bash]* List repo directory
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/CLAUDE.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/vite.config.js
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/package.json
+
+**Claude:** Let me look at the source code for any hardcoded URLs that might be causing the certificate mismatch.
+
+> *[Grep]* Search content: https?://
+
+> *[Grep]* Search content: https?://
+
+> *[Grep]* Search content: https?://
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/index.html
+
+**Claude:** The site is `openall.world` deployed on GitHub Pages. The `ERR_TLS_CERT_ALTNAME_INVALID` error on GitHub Pages is almost always caused by a missing or incorrect `CNAME` file. Let me check.
+
+> *[Glob]* Search files: **/CNAME
+
+> *[Bash]* List public directory for static assets
+
+**Claude:** Found the problem. There's **no `CNAME` file** in the project. GitHub Pages requires a `CNAME` file in the deploy root to provision a TLS certificate for the custom domain `openall.world`. Without it, GitHub serves the `*.github.io` certificate, which doesn't match `openall.world` — hence `ERR_TLS_CERT_ALTNAME_INVALID`.
+
+The fix is to add `CNAME` to `public/` so Vite copies it into `dist/` on build.
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/public/CNAME
+
+**Claude:** Also need to add it to the current deploy directory so the fix takes effect immediately without a rebuild:
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-deploy/CNAME
+
+**Claude:** **问题根因：** 项目缺少 `CNAME` 文件。GitHub Pages 需要这个文件来为自定义域名 `openall.world` 签发 TLS 证书。没有它，GitHub 只会提供 `*.github.io` 的证书，访问 `openall.world` 时域名不匹配，浏览器报 `ERR_TLS_CERT_ALTNAME_INVALID`。
+
+**修复内容：**
+- `openall-repo/public/CNAME` — 添加了内容为 `openall.world` 的 CNAME 文件。Vite 构建时会自动将 `public/` 下的文件复制到 `dist/`，确保每次部署都包含它。
+- `openall-deploy/CNAME` — 同步添加，使当前已部署的版本也能生效。
+
+部署后 GitHub Pages 会自动为 `openall.world` 签发 Let's Encrypt 证书（通常几分钟内完成），TLS 错误即可消除。
+
+**Human:** 部署好了吗
+
+**Claude:** 
+
+还没有部署。我只是在本地创建了 `CNAME` 文件，还需要把 `openall-deploy` 推送到 GitHub Pages 的 `gh-pages` 分支才能生效。
+
+但这个项目目录不是 git 仓库，我无法直接推送。你需要：
+
+1. 将 `openall-deploy/` 的内容部署到 `gh-pages` 分支（确保包含 `CNAME` 文件）
+2. 或者在 `openall-repo/` 中运行 `npm run build`，确认 `dist/` 里有 `CNAME`，然后按你原有的部署流程推送
+
+需要我帮你执行部署吗？
+
+**Human:** 你全部自己做
+
+**Claude:** 好，让我来搞定整个部署流程。先了解一下当前的 git 和远程仓库状态。
+
+> *[Bash]* Check git status in repo directory
+
+> *[Bash]* Check git status in deploy directory
+
+> *[Bash]* Check remote URLs
+
+> *[Bash]* List all branches
+
+**Claude:** 没有 `gh-pages` 分支。让我先拉取最新代码，构建并部署。
+
+> *[Bash]* Pull latest changes
+
+> *[Bash]* Check recent commits
+
+**Claude:** 好，先提交 CNAME 文件到 main 分支，然后构建并部署。
+
+> *[Bash]* Stage CNAME file
+
+> *[Bash]* Commit CNAME file
+
+> *[Bash]* Build the project
+
+**Claude:** 确认构建产物中包含 CNAME 文件：
+
+> *[Bash]* Verify CNAME in dist
+
+**Claude:** CNAME 已在构建产物中。现在推送 main 分支，然后部署 `dist/` 到 `gh-pages` 分支。
+
+> *[Bash]* Push main branch
+
+**Claude:** main 已推送。现在将 `dist/` 部署到 `gh-pages` 分支：
+
+> *[Bash]* Deploy dist to gh-pages branch
+
+**Claude:** 部署完成。现在需要确认 GitHub Pages 的 Source 设置为 `gh-pages` 分支。让我检查一下：
+
+> *[Bash]* Check GitHub Pages configuration
+
+**Claude:** GitHub Pages 当前配置的是 **GitHub Actions workflow** 部署模式（`build_type: "workflow"`），源分支是 `main`，不是 `gh-pages`。而且 `https_enforced` 是 `false`。让我检查一下 workflow 配置并修复。
+
+> *[Glob]* Search files: .github/workflows/*
+
+> *[Bash]* Check GitHub Actions workflows
+
+> *[Bash]* Read deploy workflow from GitHub
+
+**Claude:** 部署流程已经存在：push 到 `main` 会自动触发 GitHub Actions 构建并部署。我刚才已经 push 了 CNAME 文件到 main，workflow 应该已经触发了。让我确认：
+
+> *[Bash]* Check recent workflow runs
+
+**Claude:** 部署 workflow 已经成功完成。现在启用 HTTPS 强制跳转：
+
+> *[Bash]* Enable HTTPS enforcement for GitHub Pages
+
+> *[Bash]* Enable HTTPS enforcement
+
+**Claude:** 证书正在签发中，GitHub 需要几分钟来为 `openall.world` 签发 Let's Encrypt 证书。先清理一下我多创建的那个不需要的 `gh-pages` 分支：
+
+> *[Bash]* Delete unnecessary gh-pages branch
+
+> *[Bash]* Clean up temporary git repo in dist
+
+**Claude:** 等一下再检查证书状态：
+
+> *[Bash]* Check Pages certificate status
+
+> *[Bash]* Check HTTPS response from openall.world
+
+> *[Bash]* Check TLS connection details
+
+**Claude:** 证书目前仍是 `*.github.io`，GitHub 正在签发新证书。让我触发一下 GitHub Pages 的证书签发：
+
+> *[Bash]* Request Pages rebuild to trigger cert provisioning
+
+> *[Bash]* Update Pages config to refresh certificate
+
+> *[Bash]* Check full Pages status
+
+> *[Bash]* Check Pages health/certificate status
+
+**Claude:** 证书签发可能需要重新触发。让我移除再重新添加自定义域名来强制 GitHub 重新签发证书：
+
+> *[Bash]* Remove custom domain temporarily
+
+> *[Bash]* Re-add custom domain to trigger cert provisioning
+
+> *[Bash]* Verify Pages config
+
+**Claude:** 现在等一两分钟让 GitHub 签发证书，然后再验证：
+
+> *[Bash]* Wait 90s then check certificate
+
+> *[Bash]* Check TLS cert details
+
+> *[Bash]* Check certificate CN
+
+> *[Bash]* Full curl verbose output
+
+> *[Bash]* Check with IPv4 only
+
+> *[Bash]* Check DNS records
+
+> *[Bash]* Check DNS via Google's public resolver
+
+> *[Bash]* Check DNS via Cloudflare resolver
+
+> *[Bash]* Directly connect to GitHub Pages IP
+
+**Claude:** 证书已经签发成功！`CN=openall.world`，由 Let's Encrypt 签发。现在启用 HTTPS 强制跳转：
+
+> *[Bash]* Enable HTTPS enforcement
+
+> *[Bash]* Verify final Pages config
+
+**Claude:** 全部完成。总结一下做了什么：
+
+1. **根因**：项目缺少 `CNAME` 文件，GitHub Pages 没有为 `openall.world` 签发专属 TLS 证书，而是使用 `*.github.io` 的证书，导致域名不匹配
+2. **修复**：在 `public/CNAME` 中添加了 `openall.world`，提交并推送到 main 分支
+3. **部署**：GitHub Actions workflow 自动触发并部署成功
+4. **证书**：GitHub 已签发 `CN=openall.world` 的 Let's Encrypt 证书（R13），TLS 握手正常，返回 HTTP 200
+5. **HTTPS 强制跳转**：已开启 `https_enforced: true`，HTTP 访问会自动跳转到 HTTPS
+
+**Human:** <task-notification>
+<task-id>b2vxb3uxn</task-id>
+<tool-use-id>toolu_012Xm4LiGJ2avfeZZkx5RJTM</tool-use-id>
+<output-file>/private/tmp/claude-501/-Users-zhangyiyi-Desktop-openall-license/df52872d-9f9a-46be-80cc-f71651a1590a/tasks/b2vxb3uxn.output</output-file>
+<status>failed</status>
+<summary>Background command "Check DNS via Google's public resolver" failed with exit code 9</summary>
+</task-notification>
+Read the output file to retrieve the result: /private/tmp/claude-501/-Users-zhangyiyi-Desktop-openall-license/df52872d-9f9a-46be-80cc-f71651a1590a/tasks/b2vxb3uxn.output
+
+**Human:** <task-notification>
+<task-id>bg0lbhihl</task-id>
+<tool-use-id>toolu_017Gjj9W8KaxzJwgNZPj9E8t</tool-use-id>
+<output-file>/private/tmp/claude-501/-Users-zhangyiyi-Desktop-openall-license/df52872d-9f9a-46be-80cc-f71651a1590a/tasks/bg0lbhihl.output</output-file>
+<status>completed</status>
+<summary>Background command "Check DNS via Cloudflare resolver" completed (exit code 0)</summary>
+</task-notification>
+Read the output file to retrieve the result: /private/tmp/claude-501/-Users-zhangyiyi-Desktop-openall-license/df52872d-9f9a-46be-80cc-f71651a1590a/tasks/bg0lbhihl.output
+
+**Claude:** 
+
+之前的 DNS 查询超时是你本地网络的问题（可能有 VPN 或 DNS 过滤），不影响实际部署。证书已经成功签发并生效，TLS 问题已修复。
+
+**Human:** 改完之后记得把这些对话openall上去
+
+> *[Bash]* List existing conversations
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-27-remove-copyleft.md
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-27-fix-tls-certificate.md
+
+> *[Bash]* Commit and push conversation record
+
+**Claude:** 对话记录已提交并推送到 `process/conversations/2026-03-27-fix-tls-certificate.md`，包含了完整的问题诊断、修复过程和验证结果。

--- a/process/conversations/2026-03-26-tidy-knitting-sundae.md
+++ b/process/conversations/2026-03-26-tidy-knitting-sundae.md
@@ -1,0 +1,241 @@
+# Conversation: tidy-knitting-sundae
+
+**Date:** 2026-03-26
+**Time:** 17:54 UTC
+**Project:** `/Users/zhangyiyi/Desktop/openall-license`
+**Branch:** `HEAD`
+**Model:** claude-opus-4-6
+**Claude Code version:** 2.1.84
+
+---
+
+**Human:** 我没注意到这个项目是copyleft的啊。和另一个claude聊了一下感觉不合适，改一下吧
+
+**Claude:** Let me first look at the project to understand the current license situation.
+
+> *[Bash]* List project files
+
+> *[Glob]* Search files: **/LICENSE*
+
+> *[Glob]* Search files: **/COPYING*
+
+> *[Glob]* Search files: *LICENSE*
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/package.json
+
+> *[Bash]* List repo root files
+
+> *[Bash]* List deploy dir files
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/CLAUDE.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/linkedin-article.md
+
+**Claude:** 我看到了。OpenAll License v1.0 的 copyleft 条款主要在 Section 6：
+
+> **6.1** Any Derivative Work must be distributed under this same License, including all Process Transparency and Automatic Sanitization obligations.
+
+以及 Human-Readable Summary 里的：
+
+> **Same License Forward** — Derivative works must also use the OpenAll License.
+
+去掉 copyleft 之前想确认一下你的意图——因为这会直接影响 Process Transparency 的传递性：
+
+1. **完全 permissive**：衍生作品可以用任何 license，不要求继承 OpenAll（但这意味着下游可以闭源开发过程）
+2. **弱 copyleft**：衍生作品不需要用 OpenAll License，但仍然需要满足 Process Transparency 和 Sanitization 的要求（类似 "条件继承但许可证不锁定"）
+3. **其他想法**？
+
+你和另一个 Claude 聊完倾向哪个方向？
+
+**Human:** 这样，我们不要copyleft。改一下整个项目并git吧
+
+**Claude:** Let me first find all references to copyleft and the same-license-forward requirement across the project.
+
+> *[Grep]* Search content: copyleft|Same License Forward|same License|Derivative Work.*must.*distributed under this
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/decisions/001-license-design-philosophy.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-license-creation.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/inspirations/references.md
+
+> *[Glob]* Search files: .openall/**
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/ADOPTERS.md
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/README.md
+
+> *[Bash]* Check .openall dir and process dir
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/.openall/config.json
+
+> *[Grep]* Search content: copyleft|same license|Same License
+
+**Claude:** Good, `.openall/AGENT.md` and `config.json` don't reference copyleft. Now I have the full picture. Let me make all the edits.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/linkedin-article.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/decisions/001-license-design-philosophy.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/inspirations/references.md
+
+**Claude:** Now let me also update the conversation log to note this change, and handle the git init + commit. First let me check if openall-repo is already a git repo.
+
+> *[Bash]* Check git status in openall-repo
+
+> *[Bash]* Check git status in root dir
+
+**Claude:** `openall-repo` is a git repo. Let me check the full status and recent log.
+
+> *[Bash]* Show working tree status
+
+> *[Bash]* Show recent commits
+
+> *[Bash]* Show all unstaged changes
+
+**Claude:** Diff looks correct. Now let me also handle the `linkedin-article.md` — it's outside the git repo so I'll note that separately. Let me commit the repo changes.
+
+> *[Bash]* Commit copyleft removal changes
+
+**Claude:** Done. Changes committed. Here's a summary of what was changed:
+
+**LICENSE** (法律文本):
+- 移除了 Human-Readable Summary 里的 "Same License Forward" 条目
+- Section 6 从 copyleft 改为 permissive：
+  - 6.1: 衍生作品可以使用任何许可证，只需满足 Section 5 的署名要求
+  - 6.2: 明确声明衍生作品不需要采用 OpenAll License，也不需要遵守过程透明和自动脱敏义务
+
+**src/App.jsx** (网站):
+- 更新 LICENSE_SECTIONS 数据与新法律文本一致
+- 移除 "Same License Forward" 条目
+
+**process/decisions/001** & **process/inspirations/references.md**:
+- 更新设计哲学记录，将 "Copyleft Forward" 改为 "Permissive Forward"
+- 调整 Alternatives Considered，反转了原来的 copyleft vs permissive 论述
+
+**linkedin-article.md** (repo 外):
+- 已移除 copyleft 引用（但此文件不在 git repo 中）
+
+注意：`process/conversations/2026-03-26-license-creation.md` 里提到的 copyleft 决策没有修改，因为那是历史对话记录，应保持原样。
+
+**Human:** 包括网页之类在内全都改好了是吧。在网页上也可以强调一下这个不是copyleft的。然后这些聊天也需要进新的聊天记录记录，然后git上去
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Let me look at the hero section and other key areas of the page to find the best place to highlight the permissive nature.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Now I have the full picture. Let me do both things: add the "not copyleft" emphasis on the website and create the conversation record.
+
+> *[Bash]* List existing conversation records
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-26-initial-repo-push.md
+
+**Claude:** Good, I understand the format. Now let me make both changes in parallel.
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Write]* Write /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-27-remove-copyleft.md
+
+**Claude:** Now let me commit and push.
+
+> *[Bash]* Show working tree status
+
+> *[Bash]* Show unstaged changes
+
+> *[Bash]* Commit website callout and conversation record
+
+**Claude:** 现在要 push 到 origin 吗？当前 main 领先 origin 2 个 commit：
+
+1. `ccd3321` — Remove copyleft: derivative works no longer required to use OpenAll License
+2. `988fc25` — Add "not copyleft" callout on website and conversation record
+
+**Human:** 另一个claude说的：我看到你已经改了第6条，这是最关键的改动。让我对比一下变化，然后看看还有没有需要调整的地方。
+你改得好的地方：
+第6条改得很干净。原来的"must be distributed under this same License"变成了衍生作品可以用任何许可证，只需保留归属。而且6.2明确声明不要求衍生作品遵守过程透明义务。这就是 permissive 的核心，改对了。
+但还有几个地方存在内部矛盾，需要一起调整：
+Human-Readable Summary 里少了更新。 "Same License Forward"那一条在摘要里应该已经被删掉了（我看你确实删了），但 "UNDER THESE CONDITIONS" 部分的 Process Transparency 描述仍然暗示所有分发者都必须遵守，这和新的第6条矛盾。应该加一句说明：过程透明义务仅适用于原始项目的直接贡献者，不传导给下游。
+第3.1条有问题。 它写的是"Any distribution of the Software or Derivative Works must be accompanied by the corresponding Process Materials"——这里的"Derivative Works"和新的第6条冲突了。既然6.2说衍生作品不需要遵守过程透明，那3.1应该把"or Derivative Works"去掉，或者改为"Any distribution of the Software must be accompanied by its own Process Materials"。
+第7.2条可以考虑去掉。 社区未来可以对商业使用增加额外条款——这对 permissive 许可证来说是一个不确定性风险，可能会吓退商业用户。MIT 和 Apache 之所以让企业放心，就是因为条款固定、没有"未来可能加限制"的暗示。
+**第9条（合规与补救）**的措辞也值得重新审视。现在合规义务主要指向过程透明，但如果衍生作品不需要遵守，那这一条实际上只约束原始贡献者。可以在措辞上明确这个范围。
+
+**Claude:** 分析得对，这几个内部矛盾确实需要修。让我逐个处理。
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** 说得对，这四个点都是真实的内部矛盾。让我一起修。
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/LICENSE
+
+**Claude:** Now mirror all changes in App.jsx (LICENSE_SECTIONS data + summary section).
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/src/App.jsx
+
+**Claude:** Now update the conversation record to include this round.
+
+> *[Read]* Read /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-27-remove-copyleft.md
+
+> *[Edit]* Edit /Users/zhangyiyi/Desktop/openall-license/openall-repo/process/conversations/2026-03-27-remove-copyleft.md
+
+**Claude:** Now commit and push.
+
+> *[Bash]* Show changed files summary
+
+> *[Bash]* Commit internal contradiction fixes
+
+**Claude:** Done.现在 main 领先 origin 3 个 commit：
+
+1. `ccd3321` — 移除 copyleft（Section 6 重写）
+2. `988fc25` — 网站添加 "Not copyleft" callout + 对话记录
+3. `783e00b` — 修复 4 个内部矛盾：
+   - **摘要** Process Transparency 加了"仅适用于你自己的分发"的说明
+   - **§3.1** 去掉了 "or Derivative Works"
+   - **§7.2** 整条删除（不再暗示未来可能加商业限制）
+   - **§9** 新增范围界定条款，明确义务不传导给衍生作品
+
+要 push 吗？
+
+**Human:** 好的
+
+> *[Bash]* Push 3 commits to origin/main
+
+**Claude:** Pushed. 3 个 commit 已到 origin/main。

--- a/process/sanitization.log
+++ b/process/sanitization.log
@@ -24,3 +24,9 @@
 [2026-03-26 23:45 UTC+8] Sanitized .claude/hooks/check-commit.sh: clean
 [2026-03-26 23:45 UTC+8] Sanitized .claude/settings.json: clean
 [2026-03-26 23:50 UTC+8] Sanitized src/App.jsx: clean
+
+--- Export: 2026-03-27T03:32:25.485088 ---
+Sessions exported: 3
+Total redactions: 2
+
+  - @\2: 2

--- a/tools/openall-export.py
+++ b/tools/openall-export.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""
+openall-export: Convert Claude Code session logs into OpenAll /process format.
+
+Reads .jsonl session files from ~/.claude/projects/ and outputs clean,
+sanitized Markdown conversation logs compatible with the OpenAll License
+/process/conversations/ directory structure.
+
+Usage:
+    python openall-export.py                          # interactive session picker
+    python openall-export.py --session <session-id>   # export specific session
+    python openall-export.py --project <project-path> # export all sessions for a project
+    python openall-export.py --all                    # export everything
+    python openall-export.py --list                   # list available sessions
+
+Options:
+    -o, --output <dir>    Output directory (default: ./process)
+    --no-sanitize         Skip sanitization step
+    --include-tools       Include full tool use details (default: summarized)
+    --dry-run             Preview without writing files
+"""
+
+import json
+import os
+import re
+import sys
+import argparse
+import glob
+from datetime import datetime, timezone
+from pathlib import Path
+from collections import defaultdict
+
+
+# --- Sanitization patterns ---
+
+SANITIZE_PATTERNS = [
+    # API keys and tokens
+    (r'(?i)(api[_-]?key|apikey|api[_-]?token)\s*[=:]\s*["\']?([a-zA-Z0-9_\-]{20,})["\']?',
+     r'\1=***REDACTED_API_KEY***'),
+    (r'(?i)(secret[_-]?key|client[_-]?secret)\s*[=:]\s*["\']?([a-zA-Z0-9_\-]{20,})["\']?',
+     r'\1=***REDACTED_SECRET***'),
+    (r'(?i)(password|passwd|pwd)\s*[=:]\s*["\']?([^\s"\']{8,})["\']?',
+     r'\1=***REDACTED_PASSWORD***'),
+    # Bearer tokens
+    (r'(?i)(bearer\s+)([a-zA-Z0-9_\-\.]{20,})', r'\1***REDACTED_TOKEN***'),
+    # AWS keys
+    (r'AKIA[0-9A-Z]{16}', '***REDACTED_AWS_KEY***'),
+    # Private keys
+    (r'-----BEGIN\s+(RSA\s+)?PRIVATE KEY-----[\s\S]*?-----END\s+(RSA\s+)?PRIVATE KEY-----',
+     '***REDACTED_PRIVATE_KEY***'),
+    # SSH keys
+    (r'ssh-(rsa|ed25519|ecdsa)\s+[A-Za-z0-9+/=]{40,}', '***REDACTED_SSH_KEY***'),
+    # JWT tokens
+    (r'eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}',
+     '***REDACTED_JWT***'),
+    # Generic hex secrets (32+ chars)
+    (r'(?i)(token|secret|key|hash)\s*[=:]\s*["\']?([0-9a-f]{32,})["\']?',
+     r'\1=***REDACTED_HEX***'),
+    # Email addresses (partial redaction)
+    (r'([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})',
+     r'***@\2'),
+    # IPv4 addresses (internal ranges)
+    (r'\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3})\b', '***REDACTED_INTERNAL_IP***'),
+    (r'\b(192\.168\.\d{1,3}\.\d{1,3})\b', '***REDACTED_INTERNAL_IP***'),
+    (r'\b(172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3})\b', '***REDACTED_INTERNAL_IP***'),
+]
+
+
+class SanitizationLog:
+    def __init__(self):
+        self.redactions = defaultdict(int)
+        self.total = 0
+
+    def record(self, category: str, count: int = 1):
+        self.redactions[category] += count
+        self.total += count
+
+    def summary(self) -> str:
+        if self.total == 0:
+            return "No sensitive information detected."
+        lines = [f"Total redactions: {self.total}", ""]
+        for cat, count in sorted(self.redactions.items()):
+            lines.append(f"  - {cat}: {count}")
+        return "\n".join(lines)
+
+
+def sanitize(text: str, log: SanitizationLog) -> str:
+    """Apply sanitization patterns to text."""
+    for pattern, replacement in SANITIZE_PATTERNS:
+        matches = re.findall(pattern, text)
+        if matches:
+            category = replacement.split("***")[1] if "***" in replacement else "other"
+            log.record(category, len(matches))
+            text = re.sub(pattern, replacement, text)
+    return text
+
+
+def find_claude_dir() -> Path:
+    """Find the ~/.claude directory."""
+    claude_dir = Path.home() / ".claude"
+    if not claude_dir.exists():
+        print("Error: ~/.claude directory not found. Is Claude Code installed?", file=sys.stderr)
+        sys.exit(1)
+    return claude_dir
+
+
+def find_projects(claude_dir: Path) -> dict:
+    """Find all projects with session files."""
+    projects_dir = claude_dir / "projects"
+    if not projects_dir.exists():
+        return {}
+
+    projects = {}
+    for project_dir in sorted(projects_dir.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        sessions = list(project_dir.glob("*.jsonl"))
+        if sessions:
+            # Decode project path from directory name
+            name = project_dir.name.replace("-", "/")
+            projects[project_dir.name] = {
+                "path": project_dir,
+                "decoded_name": name,
+                "sessions": sessions,
+            }
+    return projects
+
+
+def parse_session(jsonl_path: Path) -> dict:
+    """Parse a .jsonl session file into structured data."""
+    messages = []
+    metadata = {
+        "session_id": jsonl_path.stem,
+        "file": str(jsonl_path),
+    }
+
+    with open(jsonl_path, "r") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            # Extract metadata from first user message
+            if not metadata.get("cwd") and entry.get("cwd"):
+                metadata["cwd"] = entry["cwd"]
+            if not metadata.get("version") and entry.get("version"):
+                metadata["version"] = entry["version"]
+            if not metadata.get("start_time") and entry.get("timestamp"):
+                metadata["start_time"] = entry["timestamp"]
+            if entry.get("timestamp"):
+                metadata["end_time"] = entry["timestamp"]
+            if entry.get("slug") and not metadata.get("slug"):
+                metadata["slug"] = entry["slug"]
+            if entry.get("gitBranch") and not metadata.get("git_branch"):
+                metadata["git_branch"] = entry["gitBranch"]
+
+            entry_type = entry.get("type")
+            msg = entry.get("message", {})
+
+            if entry_type == "user" and msg.get("role") == "user":
+                content = msg.get("content", "")
+                # User typed text
+                if isinstance(content, str) and content.strip():
+                    messages.append({
+                        "role": "human",
+                        "content": content,
+                        "timestamp": entry.get("timestamp"),
+                    })
+                # Tool results - skip (they're internal plumbing)
+
+            elif entry_type == "assistant" and msg.get("role") == "assistant":
+                content_blocks = msg.get("content", [])
+                if not isinstance(content_blocks, list):
+                    continue
+
+                for block in content_blocks:
+                    block_type = block.get("type")
+
+                    if block_type == "text" and block.get("text", "").strip():
+                        messages.append({
+                            "role": "assistant",
+                            "content": block["text"],
+                            "timestamp": entry.get("timestamp"),
+                            "model": msg.get("model", "unknown"),
+                        })
+
+                    elif block_type == "tool_use":
+                        tool_name = block.get("name", "unknown")
+                        tool_input = block.get("input", {})
+                        # Summarize tool use
+                        summary = summarize_tool_use(tool_name, tool_input)
+                        if summary:
+                            messages.append({
+                                "role": "tool",
+                                "tool": tool_name,
+                                "summary": summary,
+                                "timestamp": entry.get("timestamp"),
+                            })
+
+    return {"metadata": metadata, "messages": messages}
+
+
+def summarize_tool_use(tool_name: str, tool_input: dict) -> str:
+    """Create a one-line summary of a tool use."""
+    if tool_name == "Bash":
+        cmd = tool_input.get("command", "")
+        desc = tool_input.get("description", "")
+        return desc if desc else (cmd[:80] + "..." if len(cmd) > 80 else cmd)
+    elif tool_name == "Read":
+        return f"Read {tool_input.get('file_path', '?')}"
+    elif tool_name == "Write":
+        return f"Write {tool_input.get('file_path', '?')}"
+    elif tool_name == "Edit":
+        return f"Edit {tool_input.get('file_path', '?')}"
+    elif tool_name == "Glob":
+        return f"Search files: {tool_input.get('pattern', '?')}"
+    elif tool_name == "Grep":
+        return f"Search content: {tool_input.get('pattern', '?')}"
+    elif tool_name in ("WebFetch", "WebSearch"):
+        url = tool_input.get("url", tool_input.get("query", "?"))
+        return f"{tool_name}: {url}"
+    elif tool_name == "Agent":
+        return f"Spawned agent: {tool_input.get('description', '?')}"
+    else:
+        return f"{tool_name}"
+
+
+def format_conversation(session: dict, include_tools: bool = False) -> str:
+    """Format a parsed session into clean Markdown."""
+    meta = session["metadata"]
+    messages = session["messages"]
+
+    if not messages:
+        return ""
+
+    # Header
+    lines = []
+    lines.append(f"# Conversation: {meta.get('slug', meta['session_id'])}")
+    lines.append("")
+
+    start = meta.get("start_time", "")
+    end = meta.get("end_time", "")
+    if start:
+        try:
+            dt = datetime.fromisoformat(start.replace("Z", "+00:00"))
+            lines.append(f"**Date:** {dt.strftime('%Y-%m-%d')}")
+            lines.append(f"**Time:** {dt.strftime('%H:%M')} UTC", )
+        except (ValueError, AttributeError):
+            pass
+
+    if meta.get("cwd"):
+        lines.append(f"**Project:** `{meta['cwd']}`")
+    if meta.get("git_branch"):
+        lines.append(f"**Branch:** `{meta['git_branch']}`")
+
+    model = None
+    for m in messages:
+        if m.get("model"):
+            model = m["model"]
+            break
+    if model:
+        lines.append(f"**Model:** {model}")
+    lines.append(f"**Claude Code version:** {meta.get('version', 'unknown')}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Messages
+    prev_role = None
+    for msg in messages:
+        role = msg["role"]
+
+        if role == "human":
+            lines.append(f"**Human:** {msg['content']}")
+            lines.append("")
+            prev_role = role
+
+        elif role == "assistant":
+            lines.append(f"**Claude:** {msg['content']}")
+            lines.append("")
+            prev_role = role
+
+        elif role == "tool" and include_tools:
+            lines.append(f"> *[{msg['tool']}]* {msg['summary']}")
+            lines.append("")
+
+        elif role == "tool" and not include_tools:
+            # Compact: only show tools if between human/assistant turns
+            if prev_role == "assistant":
+                lines.append(f"> *{msg['summary']}*")
+                lines.append("")
+
+    return "\n".join(lines)
+
+
+def list_sessions(projects: dict):
+    """Print available sessions."""
+    for proj_key, proj in projects.items():
+        print(f"\n{'=' * 60}")
+        print(f"Project: {proj['decoded_name']}")
+        print(f"  Path: {proj['path']}")
+        print(f"  Sessions: {len(proj['sessions'])}")
+
+        for session_file in sorted(proj["sessions"], key=lambda p: p.stat().st_mtime, reverse=True):
+            mtime = datetime.fromtimestamp(session_file.stat().st_mtime)
+            size_kb = session_file.stat().st_size / 1024
+            # Try to get slug from first few lines
+            slug = session_file.stem
+            try:
+                with open(session_file) as f:
+                    for line in f:
+                        entry = json.loads(line)
+                        if entry.get("slug"):
+                            slug = entry["slug"]
+                            break
+                        # Only scan first 20 lines
+                        if f.tell() > 5000:
+                            break
+            except (json.JSONDecodeError, IOError):
+                pass
+
+            print(f"    [{mtime.strftime('%Y-%m-%d %H:%M')}] {slug} ({size_kb:.0f}KB)")
+
+
+def interactive_picker(projects: dict) -> list:
+    """Simple interactive session picker."""
+    all_sessions = []
+    for proj_key, proj in projects.items():
+        for sf in proj["sessions"]:
+            all_sessions.append((proj["decoded_name"], sf))
+
+    # Sort by mtime descending
+    all_sessions.sort(key=lambda x: x[1].stat().st_mtime, reverse=True)
+
+    print("\nAvailable sessions (most recent first):\n")
+    for i, (proj_name, sf) in enumerate(all_sessions[:20]):
+        mtime = datetime.fromtimestamp(sf.stat().st_mtime)
+        size_kb = sf.stat().st_size / 1024
+        slug = sf.stem[:30]
+        try:
+            with open(sf) as f:
+                for line in f:
+                    entry = json.loads(line)
+                    if entry.get("slug"):
+                        slug = entry["slug"]
+                        break
+                    if f.tell() > 5000:
+                        break
+        except (json.JSONDecodeError, IOError):
+            pass
+
+        proj_short = proj_name.split("/")[-1] if "/" in proj_name else proj_name
+        print(f"  [{i}] {mtime.strftime('%m-%d %H:%M')} | {proj_short:20s} | {slug} ({size_kb:.0f}KB)")
+
+    print()
+    selection = input("Select session(s) to export (comma-separated numbers, or 'all'): ").strip()
+
+    if selection.lower() == "all":
+        return [sf for _, sf in all_sessions]
+
+    indices = []
+    for part in selection.split(","):
+        part = part.strip()
+        if part.isdigit() and int(part) < len(all_sessions):
+            indices.append(int(part))
+
+    return [all_sessions[i][1] for i in indices]
+
+
+def export_session(session_file: Path, output_dir: Path, sanitize_enabled: bool,
+                   include_tools: bool, dry_run: bool) -> tuple:
+    """Export a single session. Returns (output_path, sanitization_log)."""
+    san_log = SanitizationLog()
+
+    session = parse_session(session_file)
+    if not session["messages"]:
+        return None, san_log
+
+    markdown = format_conversation(session, include_tools=include_tools)
+    if not markdown:
+        return None, san_log
+
+    if sanitize_enabled:
+        markdown = sanitize(markdown, san_log)
+
+    # Determine filename
+    start = session["metadata"].get("start_time", "")
+    slug = session["metadata"].get("slug", session["metadata"]["session_id"][:8])
+    try:
+        dt = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        date_str = dt.strftime("%Y-%m-%d")
+    except (ValueError, AttributeError):
+        date_str = datetime.now().strftime("%Y-%m-%d")
+
+    filename = f"{date_str}-{slug}.md"
+    output_path = output_dir / "conversations" / filename
+
+    if dry_run:
+        print(f"\n[DRY RUN] Would write: {output_path}")
+        print(f"  Messages: {len(session['messages'])}")
+        print(f"  Sanitization: {san_log.summary()}")
+        # Show first few lines
+        preview = markdown[:500]
+        print(f"  Preview:\n{preview}\n  ...")
+    else:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w") as f:
+            f.write(markdown)
+        print(f"  Exported: {output_path}")
+
+    return output_path, san_log
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export Claude Code sessions to OpenAll /process format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--session", "-s", help="Export specific session by ID")
+    parser.add_argument("--project", "-p", help="Export all sessions for a project path")
+    parser.add_argument("--all", "-a", action="store_true", help="Export all sessions")
+    parser.add_argument("--list", "-l", action="store_true", help="List available sessions")
+    parser.add_argument("--output", "-o", default="./process", help="Output directory (default: ./process)")
+    parser.add_argument("--no-sanitize", action="store_true", help="Skip sanitization")
+    parser.add_argument("--include-tools", action="store_true", help="Include full tool use details")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing")
+
+    args = parser.parse_args()
+
+    claude_dir = find_claude_dir()
+    projects = find_projects(claude_dir)
+
+    if not projects:
+        print("No Claude Code sessions found.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.list:
+        list_sessions(projects)
+        sys.exit(0)
+
+    # Determine which sessions to export
+    session_files = []
+
+    if args.session:
+        # Find by session ID
+        for proj in projects.values():
+            for sf in proj["sessions"]:
+                if args.session in sf.stem:
+                    session_files.append(sf)
+        if not session_files:
+            print(f"Session not found: {args.session}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.project:
+        # Find by project path
+        target = args.project.replace("/", "-").replace("~", "").lstrip("-")
+        for proj_key, proj in projects.items():
+            if target in proj_key or args.project in proj["decoded_name"]:
+                session_files.extend(proj["sessions"])
+        if not session_files:
+            print(f"No sessions found for project: {args.project}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.all:
+        for proj in projects.values():
+            session_files.extend(proj["sessions"])
+
+    else:
+        # Interactive picker
+        session_files = interactive_picker(projects)
+
+    if not session_files:
+        print("No sessions selected.")
+        sys.exit(0)
+
+    # Export
+    output_dir = Path(args.output)
+    total_san_log = SanitizationLog()
+    exported = 0
+
+    print(f"\nExporting {len(session_files)} session(s) to {output_dir}/conversations/\n")
+
+    for sf in session_files:
+        path, san_log = export_session(
+            sf, output_dir,
+            sanitize_enabled=not args.no_sanitize,
+            include_tools=args.include_tools,
+            dry_run=args.dry_run,
+        )
+        if path:
+            exported += 1
+            for cat, count in san_log.redactions.items():
+                total_san_log.record(cat, count)
+
+    # Write sanitization log
+    if not args.dry_run and exported > 0:
+        san_log_path = output_dir / "sanitization.log"
+        with open(san_log_path, "a") as f:
+            f.write(f"\n--- Export: {datetime.now().isoformat()} ---\n")
+            f.write(f"Sessions exported: {exported}\n")
+            f.write(total_san_log.summary())
+            f.write("\n")
+
+    print(f"\nDone. Exported {exported} session(s).")
+    if total_san_log.total > 0:
+        print(f"Sanitization: {total_san_log.total} redaction(s) applied.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The OpenAll License requires process transparency, but no tooling exists to make it happen. This PR adds the first piece of that toolchain.

**`tools/openall-export.py`** — a CLI tool that converts Claude Code session logs (`.jsonl` files in `~/.claude/`) into clean, sanitized Markdown files for the `/process/conversations/` directory.

### Features
- **Interactive session picker** — browse and select sessions to export
- **Per-project export** — `--project <path>` to export all sessions for a specific project
- **Automatic sanitization** — regex-based redaction of API keys, passwords, tokens, SSH keys, JWTs, internal IPs, email addresses
- **Sanitization log** — every redaction is logged to `process/sanitization.log`
- **Tool use summarization** — condenses verbose tool calls into readable one-liners
- **Dry run mode** — preview before writing

### Usage
```bash
python tools/openall-export.py --list                    # list available sessions
python tools/openall-export.py                           # interactive picker
python tools/openall-export.py --project openall-license # export all sessions for a project
python tools/openall-export.py --all --dry-run           # preview everything
```

### Proof: 3 real conversations auto-exported

This PR also includes 3 Claude Code conversations from this project, exported by the tool itself:
- `2026-03-26-clever-jumping-valley.md` — the main Day 1 development session (557 messages)
- `2026-03-26-tidy-knitting-sundae.md` — removing copyleft from the license
- `2026-03-26-moonlit-crafting-duckling.md` — fixing the TLS certificate

2 email addresses were automatically redacted during export.

## Context

This was built during a conversation where the OpenAll project was discussed, critiqued, and ultimately handed to Claude to work on. The core insight: OpenAll needs tooling before it needs more license text. A license that requires process transparency but provides no tools to achieve it is asking developers to do manual work — which defeats the "zero effort" promise.

This tool is Step 1. It proves that Claude Code's existing log infrastructure can feed directly into OpenAll's `/process` directory with zero manual effort from the developer.

## Test plan
- [x] `--list` shows all available sessions across projects
- [x] `--dry-run` previews output without writing
- [x] `--project openall-license` correctly exports 3 sessions
- [x] Sanitization detects and redacts email addresses
- [x] Output Markdown is clean and readable
- [ ] Test on Linux/Windows paths
- [ ] Test with very large sessions (>10MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)